### PR TITLE
FEAT(#23): 공지사항 상세페이지 스크린 UI 구현

### DIFF
--- a/lib/core/screens/tab_screen.dart
+++ b/lib/core/screens/tab_screen.dart
@@ -21,22 +21,22 @@ class TabScreen extends StatefulWidget {
 class _TabScreenState extends State<TabScreen> {
   int _selectedTabIndex = 0;
 
-  // Teacher Body 위젯 리스트
-  final List<Widget> _tabBodies = [
-    const TeacherHomeScreen(), // Home Screen
-    TeacherNoticeListScreen(), // Notice Screen
-    TeacherNoteListScreen(), // Note Screen
-    const TeacherPhotoListScreen(), // Photo Screen
-    const TeacherInfoUpdateScreen(), // Info Screen
-  ];
-  // // Parent Body 위젯 리스트
+  // // Teacher Body 위젯 리스트
   // final List<Widget> _tabBodies = [
-  //   const ParentHomeScreen(), // Home Screen
-  //   ParentNoticeListScreen(), // Notice Screen
-  //   ParentNoteListScreen(), // Note Screen
-  //   const ParentPhotoListScreen(), // Photo Screen
-  //   const ParentInfoUpdateScreen(), // Info Screen
+  //   const TeacherHomeScreen(), // Home Screen
+  //   TeacherNoticeListScreen(), // Notice Screen
+  //   TeacherNoteListScreen(), // Note Screen
+  //   const TeacherPhotoListScreen(), // Photo Screen
+  //   const TeacherInfoUpdateScreen(), // Info Screen
   // ];
+  // Parent Body 위젯 리스트
+  final List<Widget> _tabBodies = [
+    const ParentHomeScreen(), // Home Screen
+    ParentNoticeListScreen(), // Notice Screen
+    ParentNoteListScreen(), // Note Screen
+    const ParentPhotoListScreen(), // Photo Screen
+    const ParentInfoUpdateScreen(), // Info Screen
+  ];
 
   // BottomNavigationBarItem label 리스트
   final List<String> _tabLabels = [

--- a/lib/features/notices/screens/teacher_notice_detail_screen.dart
+++ b/lib/features/notices/screens/teacher_notice_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
 import '../models/notice_model.dart';
+import 'notice_insert_screen.dart';
 
 class TeacherNoticeDetailScreen extends StatelessWidget {
 
@@ -48,10 +49,10 @@ class TeacherNoticeDetailScreen extends StatelessWidget {
                       child: TextButton.icon(
                         onPressed: () {
                           // 공지사항 작성하는 스크린 넘어가도록 작업예정
-                          // Navigator.push(
-                          //   context,
-                          //   MaterialPageRoute(builder: (context) => const NoteInsertScreen()),
-                          // );
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => const NoticeInsertScreen()),
+                          );
                         }, // 알림장 수정 기능
                         label: const Text(
                           "수정하기",


### PR DESCRIPTION
## 💥 연관된 이슈
#23

## 🔨 작업 내용
- 공지사항 상세 스크린(교사/학부모 각각) 생성
- 리스트 탭 시 알림장 상세 스크린으로 연결
- 삭제하기 버튼 탭 시 리스트 삭제, 삭제 후 리스트로 복귀, 리스트 최신 상태 반영
- 수정하기 버튼 클릭 시 수정 스크린으로 이동