### PR TITLE
FEAT(#33): 교사 소속정보 수정 스크린 생성 및 연결

### DIFF
--- a/lib/features/auth/screens/center_info_insert_screen.dart
+++ b/lib/features/auth/screens/center_info_insert_screen.dart
@@ -1,0 +1,96 @@
+import 'package:aimory_app/core/const/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart'; // 날짜 포맷을 위해 추가
+
+import '../../../core/widgets/custom_button.dart';
+import '../../../core/widgets/custom_input_decoration.dart';
+
+class CenterInfoInsertScreen extends StatefulWidget {
+  const CenterInfoInsertScreen({Key? key}) : super(key: key);
+
+  @override
+  State<CenterInfoInsertScreen> createState() => _CenterInfoInsertScreenState();
+}
+
+class _CenterInfoInsertScreenState extends State<CenterInfoInsertScreen> {
+  final TextEditingController _dateController = TextEditingController();
+
+  @override
+  void dispose() {
+    _dateController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        centerTitle: true,
+        title: const Text(
+          '소속 정보 수정',
+          style: TextStyle(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.keyboard_backspace_sharp),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+
+            // TODO : 카메라/갤러리 연동하여 바꿀 수 있도록
+            SizedBox(
+              height: 120.0,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  CircleAvatar(
+                    radius: 40,
+                    backgroundColor: Colors.grey,
+                  ),
+                ],
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            const Text('소속'),
+            const SizedBox(height: 8),
+
+            TextFormField(
+              readOnly: true, // 수정 불가능하도록 설정
+              initialValue:  null, // TODO: 유저 이름 데이터 표시
+              decoration: CustomInputDecoration.basic(
+                hintText: '소속을 입력하세요.',
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text('반'),
+            const SizedBox(height: 8),
+            TextFormField(
+              obscureText: true,
+              decoration: CustomInputDecoration.basic(
+                hintText: '해당 반을 입력하세요.',
+              ),
+            ),
+            const SizedBox(height: 24),
+            CustomButton(
+              text: '등록하기',
+              onPressed: () {
+                // TODO : 클릭 시 이벤트
+                print('등록하기 버튼 클릭');
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/screens/parent_info_screen.dart
+++ b/lib/features/auth/screens/parent_info_screen.dart
@@ -1,6 +1,8 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
 
+import 'info_insert_screen.dart';
+
 class ParentInfoScreen extends StatelessWidget {
   const ParentInfoScreen({Key? key}) : super(key: key);
 

--- a/lib/features/auth/screens/teacher_info_screen.dart
+++ b/lib/features/auth/screens/teacher_info_screen.dart
@@ -1,6 +1,7 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
 
+import 'center_info_insert_screen.dart';
 import 'info_insert_screen.dart';
 
 class TeacherInfoScreen extends StatelessWidget {
@@ -84,7 +85,12 @@ class TeacherInfoScreen extends StatelessWidget {
                     ),
 
                     GestureDetector(
-                      onTap: () {},
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (context) => const CenterInfoInsertScreen()),
+                        );
+                      },
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.center,
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -95,7 +101,7 @@ class TeacherInfoScreen extends StatelessWidget {
                           SizedBox(
                             width: 80.0, // 버튼의 고정 너비 설정
                             child: Text(
-                              '소속 정보 수정', // 예시 텍스트
+                              '소속 정보 등록', // 예시 텍스트
                               textAlign: TextAlign.center, // 텍스트 가운데 정렬
                               style: TextStyle(fontSize: 12, color: BLACK_COLOR,),
                               maxLines: 2, // 최대 줄 수 설정


### PR DESCRIPTION
## 💥 연관된 이슈
#3

## 🔨 작업 내용
- 원 소속 정보 TextField 등 포함된 스크린 구현
- 교사 내 정보 스크린 '소속 정보 등록' 버튼 탭 시 연결

## 👀작업 결과 이미지
![Screen_Recording_20250114_141954_1](https://github.com/user-attachments/assets/d33982e6-4120-4b6d-8c32-2e90bbef42a6)
