### PR TITLE
FEAT(#34): 학부모-내정보-우리 아이 정보 등록 스크린 UI 생성 및 연결

### DIFF
--- a/lib/core/screens/tab_screen.dart
+++ b/lib/core/screens/tab_screen.dart
@@ -21,22 +21,22 @@ class TabScreen extends StatefulWidget {
 class _TabScreenState extends State<TabScreen> {
   int _selectedTabIndex = 0;
 
-  // Teacher Body 위젯 리스트에서
-  final List<Widget> _tabBodies = [
-    const TeacherHomeScreen(), // Home Screen
-    TeacherNoticeListScreen(), // Notice Screen
-    TeacherNoteListScreen(), // Note Screen
-    const TeacherPhotoListScreen(), // Photo Screen
-    TeacherInfoScreen(), // Info Screen
-  ];
-  // // Parent Body 위젯 리스트
+  // // Teacher Body 위젯 리스트에서
   // final List<Widget> _tabBodies = [
-  //   const ParentHomeScreen(), // Home Screen
-  //   ParentNoticeListScreen(), // Notice Screen
-  //   ParentNoteListScreen(), // Note Screen
-  //   const ParentPhotoListScreen(), // Photo Screen
-  //   ParentInfoScreen(), // Info Screen
+  //   const TeacherHomeScreen(), // Home Screen
+  //   TeacherNoticeListScreen(), // Notice Screen
+  //   TeacherNoteListScreen(), // Note Screen
+  //   const TeacherPhotoListScreen(), // Photo Screen
+  //   TeacherInfoScreen(), // Info Screen
   // ];
+  // Parent Body 위젯 리스트
+  final List<Widget> _tabBodies = [
+    const ParentHomeScreen(), // Home Screen
+    ParentNoticeListScreen(), // Notice Screen
+    ParentNoteListScreen(), // Note Screen
+    const ParentPhotoListScreen(), // Photo Screen
+    ParentInfoScreen(), // Info Screen
+  ];
 
   // BottomNavigationBarItem label 리스트
   final List<String> _tabLabels = [

--- a/lib/features/auth/screens/child_info_insert_screen.dart
+++ b/lib/features/auth/screens/child_info_insert_screen.dart
@@ -5,14 +5,14 @@ import 'package:intl/intl.dart'; // 날짜 포맷을 위해 추가
 import '../../../core/widgets/custom_button.dart';
 import '../../../core/widgets/custom_input_decoration.dart';
 
-class CenterInfoInsertScreen extends StatefulWidget {
-  const CenterInfoInsertScreen({Key? key}) : super(key: key);
+class ChildInfoInsertScreen extends StatefulWidget {
+  const ChildInfoInsertScreen({Key? key}) : super(key: key);
 
   @override
-  State<CenterInfoInsertScreen> createState() => _CenterInfoInsertScreenState();
+  State<ChildInfoInsertScreen> createState() => _ChildInfoInsertScreenState();
 }
 
-class _CenterInfoInsertScreenState extends State<CenterInfoInsertScreen> {
+class _ChildInfoInsertScreenState extends State<ChildInfoInsertScreen> {
   final TextEditingController _dateController = TextEditingController();
 
   @override
@@ -28,7 +28,7 @@ class _CenterInfoInsertScreenState extends State<CenterInfoInsertScreen> {
         backgroundColor: Colors.white,
         centerTitle: true,
         title: const Text(
-          '소속 정보 등록',
+          '아이 정보 등록',
           style: TextStyle(
             fontWeight: FontWeight.w600,
           ),
@@ -57,6 +57,27 @@ class _CenterInfoInsertScreenState extends State<CenterInfoInsertScreen> {
                     backgroundColor: Colors.grey,
                   ),
                 ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text('이름'),
+            const SizedBox(height: 8),
+
+            TextFormField(
+              readOnly: true, // 수정 불가능하도록 설정
+              initialValue:  null, // TODO: 유저 이름 데이터 표시
+              decoration: CustomInputDecoration.basic(
+                hintText: '이름을 입력하세요.',
+              ),
+            ),
+            // TODO : 달력 위젯 연동
+            const SizedBox(height: 16),
+            const Text('생년월일'),
+            const SizedBox(height: 8),
+            TextFormField(
+              obscureText: true,
+              decoration: CustomInputDecoration.basic(
+                hintText: '생년월일을 입력하세요.',
               ),
             ),
 

--- a/lib/features/auth/screens/parent_info_screen.dart
+++ b/lib/features/auth/screens/parent_info_screen.dart
@@ -1,6 +1,7 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
 
+import 'child_info_insert_screen.dart';
 import 'info_insert_screen.dart';
 
 class ParentInfoScreen extends StatelessWidget {
@@ -84,7 +85,12 @@ class ParentInfoScreen extends StatelessWidget {
                     ),
 
                     GestureDetector(
-                      onTap: () {},
+                      onTap: () {
+                        Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => const ChildInfoInsertScreen()),
+                        );
+                      },
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.center,
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/features/auth/screens/parent_info_screen.dart
+++ b/lib/features/auth/screens/parent_info_screen.dart
@@ -101,7 +101,7 @@ class ParentInfoScreen extends StatelessWidget {
                           SizedBox(
                             width: 80.0, // 버튼의 고정 너비 설정
                             child: Text(
-                              '아이 정보 수정', // 예시 텍스트
+                              '아이 정보 등', // 예시 텍스트
                               textAlign: TextAlign.center, // 텍스트 가운데 정렬
                               style: TextStyle(fontSize: 12, color: BLACK_COLOR,),
                               maxLines: 2, // 최대 줄 수 설정


### PR DESCRIPTION
## 💥 연관된 이슈
#34

## 🔨 작업 내용
- 아이 정보 등록 TextField 등 포함된 스크린 구현
- 부모 내 정보 스크린 '아이 정보 등록' 버튼 탭 시 연결

## 👀작업 결과 이미지
![Screen_Recording_20250114_144841_1](https://github.com/user-attachments/assets/efc70198-cd24-4510-bea3-9fab7bc2116d)
