### PR TITLE
FEAT(#41): 사진첩 원아별 앨범 리스트뷰 스크린 UI 구현

### DIFF
--- a/lib/core/screens/tab_screen.dart
+++ b/lib/core/screens/tab_screen.dart
@@ -1,14 +1,9 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
-import '../../features/auth/screens/parent_info_screen.dart';
-import '../../features/home/screens/parent_home_screen.dart';
 import '../../features/home/screens/teacher_home_screen.dart';
-import '../../features/notes/screens/parent_note_list_screen.dart';
-import '../../features/notices/screens/parent_notice_list_screen.dart';
 import '../../features/notices/screens/teacher_notice_list_screen.dart';
 import '../../features/notes/screens/teacher_note_list_screen.dart';
-import '../../features/photos/screens/parent_photo_list_screen.dart';
-import '../../features/photos/screens/teacher_photo_list_screen.dart';
+import '../../features/photos/screens/teacher_album_screen.dart';
 import '../../features/auth/screens/teacher_info_screen.dart';
 
 class TabScreen extends StatefulWidget {
@@ -21,22 +16,22 @@ class TabScreen extends StatefulWidget {
 class _TabScreenState extends State<TabScreen> {
   int _selectedTabIndex = 0;
 
-  // // Teacher Body 위젯 리스트에서
-  // final List<Widget> _tabBodies = [
-  //   const TeacherHomeScreen(), // Home Screen
-  //   TeacherNoticeListScreen(), // Notice Screen
-  //   TeacherNoteListScreen(), // Note Screen
-  //   const TeacherPhotoListScreen(), // Photo Screen
-  //   TeacherInfoScreen(), // Info Screen
-  // ];
-  // Parent Body 위젯 리스트
+  // Teacher Body 위젯 리스트에서
   final List<Widget> _tabBodies = [
-    const ParentHomeScreen(), // Home Screen
-    ParentNoticeListScreen(), // Notice Screen
-    ParentNoteListScreen(), // Note Screen
-    const ParentPhotoListScreen(), // Photo Screen
-    ParentInfoScreen(), // Info Screen
+    const TeacherHomeScreen(), // Home Screen
+    TeacherNoticeListScreen(), // Notice Screen
+    TeacherNoteListScreen(), // Note Screen
+    TeacherAlbumScreen(), // Photo Screen
+    TeacherInfoScreen(), // Info Screen
   ];
+  // // Parent Body 위젯 리스트
+  // final List<Widget> _tabBodies = [
+  //   const ParentHomeScreen(), // Home Screen
+  //   ParentNoticeListScreen(), // Notice Screen
+  //   ParentNoteListScreen(), // Note Screen
+  //   ParentPhotoListScreen(), // Photo Screen
+  //   ParentInfoScreen(), // Info Screen
+  // ];
 
   // BottomNavigationBarItem label 리스트
   final List<String> _tabLabels = [

--- a/lib/features/photos/screens/teacher_album_screen.dart
+++ b/lib/features/photos/screens/teacher_album_screen.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/const/colors.dart';
+
+class TeacherAlbumScreen extends StatelessWidget {
+  const TeacherAlbumScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          Container(
+            color: F4_GREY_COLOR,
+            padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end, // 버튼을 오른쪽 정렬
+              children: [
+                TextButton.icon(
+                  onPressed: () {
+                    // Navigator.push(
+                    //   context,
+                    //   MaterialPageRoute(builder: (context) => const PhotoInsertScreen()),
+                    // );
+                  }, // 사진 추가 버튼 기능
+                  label: const Text(
+                    "사진 추가하기",
+                    style: TextStyle(
+                      color: DARK_GREY_COLOR,
+                      fontSize: 14,
+                    ),
+                  ),
+                  style: TextButton.styleFrom(
+                    backgroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                      side: BorderSide(
+                        color: MID_GREY_COLOR, // 테두리 색상
+                        width: 1, // 테두리 두께
+                      ),
+                    ),
+                  ),
+                  icon: Icon(Icons.add, color: DARK_GREY_COLOR), // 아이콘 추가
+                ),
+              ],
+            ),
+          ),
+          SizedBox(height: 10),
+          // 사진첩 그리드뷰
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(16.0),
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2, // 한 줄에 두 개의 아이템
+                mainAxisSpacing: 16.0,
+                crossAxisSpacing: 16.0,
+                childAspectRatio: 1, // 정사각형 비율
+              ),
+              itemCount: 4, // 그리드 아이템 개수
+              itemBuilder: (context, index) {
+                final titles = ['전체(222)', '이채은(222)', '송유리(222)', '권재아(222)'];
+                return Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Container(
+                      width: double.infinity,
+                      height: 120,
+                      color: Colors.grey[300],
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      titles[index],
+                      style: TextStyle(fontSize: 14),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 💥 연관된 이슈
#41

## 🔨 작업 내용
- 교사 원아별 앨범 스크린뷰 구현(이미지/하단 텍스트)
- 상단 '사진추가하기' 버튼 UI 생성(교사만)

## 👀작업 결과 이미지
![Screen_Recording_20250115_165607_1](https://github.com/user-attachments/assets/3877e8c4-df11-47cf-9010-828f55f67a79)
