### PR TITLE
FEAT(#42): 사진첩 리스트 스크린 생성 및 UI 구현

### DIFF
--- a/lib/core/screens/tab_screen.dart
+++ b/lib/core/screens/tab_screen.dart
@@ -1,8 +1,13 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
+import '../../features/auth/screens/parent_info_screen.dart';
+import '../../features/home/screens/parent_home_screen.dart';
 import '../../features/home/screens/teacher_home_screen.dart';
+import '../../features/notes/screens/parent_note_list_screen.dart';
+import '../../features/notices/screens/parent_notice_list_screen.dart';
 import '../../features/notices/screens/teacher_notice_list_screen.dart';
 import '../../features/notes/screens/teacher_note_list_screen.dart';
+import '../../features/photos/screens/parent_photo_list_screen.dart';
 import '../../features/photos/screens/teacher_album_screen.dart';
 import '../../features/auth/screens/teacher_info_screen.dart';
 
@@ -16,22 +21,9 @@ class TabScreen extends StatefulWidget {
 class _TabScreenState extends State<TabScreen> {
   int _selectedTabIndex = 0;
 
-  // Teacher Body 위젯 리스트에서
-  final List<Widget> _tabBodies = [
-    const TeacherHomeScreen(), // Home Screen
-    TeacherNoticeListScreen(), // Notice Screen
-    TeacherNoteListScreen(), // Note Screen
-    TeacherAlbumScreen(), // Photo Screen
-    TeacherInfoScreen(), // Info Screen
-  ];
-  // // Parent Body 위젯 리스트
-  // final List<Widget> _tabBodies = [
-  //   const ParentHomeScreen(), // Home Screen
-  //   ParentNoticeListScreen(), // Notice Screen
-  //   ParentNoteListScreen(), // Note Screen
-  //   ParentPhotoListScreen(), // Photo Screen
-  //   ParentInfoScreen(), // Info Screen
-  // ];
+  // 부모 사용자와 연관된 원아 정보를 저장(임시)
+  final int parentChildId = 123;
+
 
   // BottomNavigationBarItem label 리스트
   final List<String> _tabLabels = [
@@ -67,7 +59,19 @@ class _TabScreenState extends State<TabScreen> {
       ),
       body: IndexedStack(
         index: _selectedTabIndex,
-        children: _tabBodies,
+        children: [
+          // const TeacherHomeScreen(), // Home Screen
+          // TeacherNoticeListScreen(), // Notice Screen
+          // TeacherNoteListScreen(), // Note Screen
+          // TeacherAlbumScreen(), // Photo Screen
+          // TeacherInfoScreen(), // Info Screen
+
+          const ParentHomeScreen(),
+          ParentNoticeListScreen(),
+          ParentNoteListScreen(),
+          ParentPhotoListScreen(childId: parentChildId), // 데이터를 직접 전달
+          ParentInfoScreen(),
+        ],
       ),
       bottomNavigationBar: BottomNavigationBar(
         backgroundColor: Colors.white,

--- a/lib/features/photos/models/album_model.dart
+++ b/lib/features/photos/models/album_model.dart
@@ -1,0 +1,22 @@
+class Album {
+  final int childId;
+  final String name;
+  final String profileImageUrl;
+  final int count;
+
+  Album({
+    required this.childId,
+    required this.name,
+    required this.profileImageUrl,
+    required this.count,
+  });
+
+  factory Album.fromJson(Map<String, dynamic> json) {
+    return Album(
+      childId: json['childId'] as int,
+      name: json['name'] as String,
+      profileImageUrl: json['profileImageUrl'] as String,
+      count: json['count'] as int,
+    );
+  }
+}

--- a/lib/features/photos/models/photo_model.dart
+++ b/lib/features/photos/models/photo_model.dart
@@ -1,0 +1,16 @@
+class Photo {
+  final int photoId;
+  final String imageUrl;
+
+  Photo({
+    required this.photoId,
+    required this.imageUrl,
+  });
+
+  factory Photo.fromJson(Map<String, dynamic> json) {
+    return Photo(
+      photoId: json['photoId'] as int,
+      imageUrl: json['imageUrl'] as String,
+    );
+  }
+}

--- a/lib/features/photos/screens/parent_photo_list_screen.dart
+++ b/lib/features/photos/screens/parent_photo_list_screen.dart
@@ -1,12 +1,106 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:aimory_app/core/const/colors.dart';
 
-class ParentPhotoListScreen extends StatelessWidget {
-  const ParentPhotoListScreen({Key? key}) : super(key: key);
+import '../models/album_model.dart';
+import '../services/album_service.dart';
+
+class ParentPhotoListScreen extends StatefulWidget {
+  final int childId;
+
+  const ParentPhotoListScreen({
+    Key? key,
+    required this.childId,
+  }) : super(key: key);
+
+  @override
+  State<ParentPhotoListScreen> createState() => _ParentPhotoListScreenState();
+}
+
+class _ParentPhotoListScreenState extends State<ParentPhotoListScreen> {
+  late Future<Album> album;
+
+  @override
+  void initState() {
+    super.initState();
+    // album = AlbumService().fetchAlbumByChildId(widget.childId);
+    album = _fetchAlbumMock();
+  }
+
+  // 임시 데이터를 반환하는 함수
+  Future<Album> _fetchAlbumMock() async {
+    await Future.delayed(const Duration(seconds: 1)); // 로딩 효과를 위해 딜레이 추가
+    return Album(
+      childId: widget.childId,
+      name: '이채은',
+      profileImageUrl: 'https://imgnews.pstatic.net/image/056/2025/01/15/0011875678_001_20250115182816671.jpg', // 샘플 이미지 URL
+      count: 9, // 사진 개수
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text("학부모 앨범 화면", style: TextStyle(fontSize: 24)),
+    return Scaffold(
+      body: FutureBuilder<Album>(
+        future: album,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('오류 발생: ${snapshot.error}'));
+          }
+
+          final data = snapshot.data!;
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 상단 정보 (사진 개수, 원아 이름)
+                Text(
+                  '${data.count}개',
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  data.name,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    color: Colors.grey,
+                  ),
+                ),
+                const SizedBox(height: 16),
+
+                // 사진 GridView
+                Expanded(
+                  child: GridView.builder(
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 3, // 한 줄에 세 개의 사진
+                      mainAxisSpacing: 8.0,
+                      crossAxisSpacing: 8.0,
+                    ),
+                    itemCount: data.count,
+                    itemBuilder: (context, index) {
+                      return Container(
+                        decoration: BoxDecoration(
+                          color: LIGHT_GREY_COLOR, // 기본 배경색
+                          image: DecorationImage(
+                            image: NetworkImage(data.profileImageUrl), // 네트워크 이미지 표시
+                            fit: BoxFit.cover,
+                          ),
+                          borderRadius: BorderRadius.circular(8.0),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/features/photos/screens/teacher_album_screen.dart
+++ b/lib/features/photos/screens/teacher_album_screen.dart
@@ -1,9 +1,50 @@
+import 'package:aimory_app/features/photos/screens/teacher_photo_list_screen.dart';
 import 'package:flutter/material.dart';
-
 import '../../../core/const/colors.dart';
+import '../models/album_model.dart';
+import '../services/album_service.dart';
 
-class TeacherAlbumScreen extends StatelessWidget {
+class TeacherAlbumScreen extends StatefulWidget {
   const TeacherAlbumScreen({Key? key}) : super(key: key);
+
+  @override
+  State<TeacherAlbumScreen> createState() => _TeacherAlbumScreenState();
+}
+
+class _TeacherAlbumScreenState extends State<TeacherAlbumScreen> {
+  late Future<List<Album>> albums;
+
+  @override
+  void initState() {
+    super.initState();
+    // albums = AlbumService().fetchAlbums(); // 앨범 목록 가져오기
+    albums = _fetchAlbumsMock(); // 임시 데이터 사용
+  }
+
+  // 임시 데이터를 반환하는 함수
+  Future<List<Album>> _fetchAlbumsMock() async {
+    await Future.delayed(const Duration(seconds: 1)); // 로딩 효과를 위해 딜레이 추가
+    return [
+      Album(
+        childId: 1,
+        name: '이채은',
+        profileImageUrl: 'https://imgnews.pstatic.net/image/366/2025/01/15/0001047437_001_20250115110120234.jpg', // 샘플 이미지 URL
+        count: 12,
+      ),
+      Album(
+        childId: 2,
+        name: '송유리',
+        profileImageUrl: 'https://imgnews.pstatic.net/image/366/2025/01/15/0001047437_002_20250115110121752.jpg', // 샘플 이미지 URL
+        count: 8,
+      ),
+      Album(
+        childId: 3,
+        name: '권재아',
+        profileImageUrl: 'https://imgnews.pstatic.net/image/366/2025/01/15/0001047437_002_20250115110121752.jpg', // 샘플 이미지 URL
+        count: 15,
+      ),
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -45,35 +86,84 @@ class TeacherAlbumScreen extends StatelessWidget {
               ],
             ),
           ),
-          SizedBox(height: 10),
-          // 사진첩 그리드뷰
           Expanded(
-            child: GridView.builder(
-              padding: const EdgeInsets.all(16.0),
-              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 2, // 한 줄에 두 개의 아이템
-                mainAxisSpacing: 16.0,
-                crossAxisSpacing: 16.0,
-                childAspectRatio: 1, // 정사각형 비율
-              ),
-              itemCount: 4, // 그리드 아이템 개수
-              itemBuilder: (context, index) {
-                final titles = ['전체(222)', '이채은(222)', '송유리(222)', '권재아(222)'];
-                return Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Container(
-                      width: double.infinity,
-                      height: 120,
-                      color: Colors.grey[300],
-                    ),
-                    SizedBox(height: 8),
-                    Text(
-                      titles[index],
-                      style: TextStyle(fontSize: 14),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
+            child: FutureBuilder<List<Album>>(
+              future: albums,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                } else if (snapshot.hasError) {
+                  return Center(child: Text('오류 발생: ${snapshot.error}'));
+                }
+
+                final albumList = snapshot.data ?? [];
+
+                // 맨 앞의 전체 앨범
+                final allAlbums = [
+                  Album(
+                    childId: 0, // "전체 앨범"의 childId는 0으로 설정
+                    name: '전체',
+                    profileImageUrl: 'https://imgnews.pstatic.net/image/366/2025/01/15/0001047437_002_20250115110121752.jpg', // 샘플 이미지 URL
+                    count: albumList.fold(0, (sum, album) => sum + album.count), // 모든 사진의 합
+                  ),
+                  ...albumList, // 원래의 앨범 리스트
+                ];
+
+                return GridView.builder(
+                  padding: const EdgeInsets.all(16.0),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2, // 한 줄에 두 개의 아이템
+                    mainAxisSpacing: 16.0,
+                    crossAxisSpacing: 16.0,
+                    childAspectRatio: 1, // 정사각형 비율
+                  ),
+                  itemCount: allAlbums.length,
+                  itemBuilder: (context, index) {
+                    final album = allAlbums[index];
+                    return GestureDetector(
+                      onTap: () {
+                        // "전체 앨범" 또는 개별 앨범 클릭 시 처리
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => TeacherPhotoListScreen(
+                              childName: album.name,
+                              photoCount: album.count,
+                              photos: List.generate(
+                                album.count,
+                                    (idx) => 'https://imgnews.pstatic.net/image/366/2025/01/15/0001047437_002_20250115110121752.jpg',
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                      child: Column(
+                        children: [
+                          Expanded(
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: Colors.grey[300], // 기본 배경색
+                                image: DecorationImage(
+                                  image: NetworkImage(album.profileImageUrl),
+                                  fit: BoxFit.cover,
+                                ),
+                                borderRadius: BorderRadius.circular(8.0),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            '${album.name}(${album.count})',
+                            style: const TextStyle(
+                              fontSize: 14,
+                              color: Colors.grey,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    );
+                  },
                 );
               },
             ),

--- a/lib/features/photos/screens/teacher_photo_list_screen.dart
+++ b/lib/features/photos/screens/teacher_photo_list_screen.dart
@@ -1,12 +1,90 @@
-import 'package:flutter/cupertino.dart';
+import 'package:aimory_app/core/const/colors.dart';
+import 'package:flutter/material.dart';
 
 class TeacherPhotoListScreen extends StatelessWidget {
-  const TeacherPhotoListScreen({Key? key}) : super(key: key);
+
+  final String childName; // 원아 이름
+  final int photoCount; // 원아 사진 개수
+  final List<String> photos; // 사진 URL 리스트
+
+  const TeacherPhotoListScreen({
+    Key? key,
+    required this.childName,
+    required this.photoCount,
+    required this.photos,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text("학부모 앨범 화면", style: TextStyle(fontSize: 24)),
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        centerTitle: true,
+        title: const Text(
+          '사진첩',
+          style: TextStyle(
+            fontWeight: FontWeight.w600,
+            color: Colors.black,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.keyboard_backspace_sharp, color: Colors.black),
+          onPressed: () {
+            Navigator.pop(context); // 이전 화면으로 돌아가기
+          },
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 상단 정보 (사진 개수, 원아 이름)
+            Text(
+              '$photoCount개',
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              childName,
+              style: const TextStyle(
+                fontSize: 16,
+                color: Colors.grey,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // 사진 ListView
+            Expanded(
+              child: GridView.builder(
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3, // 한 줄에 세 개의 사진
+                  mainAxisSpacing: 8.0,
+                  crossAxisSpacing: 8.0,
+                ),
+                itemCount: photos.length,
+                itemBuilder: (context, index) {
+                  return Container(
+                    decoration: BoxDecoration(
+                      color: LIGHT_GREY_COLOR, // 기본 배경색
+                      image: photos[index].isNotEmpty
+                          ? DecorationImage(
+                        image: AssetImage(photos[index]), // 로컬 이미지 표시
+                        fit: BoxFit.cover,
+                      )
+                          : null, // 사진이 없는 경우 빈 박스
+                      borderRadius: BorderRadius.circular(8.0),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/photos/services/album_service.dart
+++ b/lib/features/photos/services/album_service.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/album_model.dart';
+
+class AlbumService {
+  final String apiUrl = 'https://api.example.com/albums'; // 앨범 관련 API 엔드포인트
+
+  // 전체 앨범 목록 조회
+  Future<List<Album>> fetchAlbums() async {
+    final response = await http.get(Uri.parse(apiUrl));
+
+    if (response.statusCode == 200) {
+      final List<dynamic> jsonData = jsonDecode(response.body)['photos'];
+
+      // JSON 데이터를 Album 객체 리스트로 변환
+      return jsonData.map((data) => Album.fromJson(data)).toList();
+    } else {
+      throw Exception('Failed to load albums');
+    }
+  }
+
+  // 특정 원아의 앨범 조회
+  Future<Album> fetchAlbumByChildId(int childId) async {
+    final response = await http.get(Uri.parse('$apiUrl/$childId'));
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonData = jsonDecode(response.body);
+
+      // JSON 데이터를 Album 객체로 변환
+      return Album.fromJson(jsonData);
+    } else {
+      throw Exception('Failed to load album for childId: $childId');
+    }
+  }
+}


### PR DESCRIPTION
## 💥 연관된 이슈
#42

## 🔨 작업 내용
- 해당 원아의 사진 리스트뷰로 UI구현
- 사진첨 앨범 스크린에서 해당 원아 탭 시 이동하도록 기능 구현

## 👀작업 결과 이미지
[학부모 유저일 때]
![Screen_Recording_20250115_211456_1](https://github.com/user-attachments/assets/01bc7063-6ab4-4405-a35d-1358a9496158)

[교사 유저일 때]
![Screen_Recording_20250115_211332_1](https://github.com/user-attachments/assets/fded856a-0fdd-4ebd-b48f-ec30e8d38c9e)
