### PR TITLE
FEAT(#43): 이미지뷰어 스크린 UI구현 및 연결

### DIFF
--- a/lib/features/photos/screens/parent_photo_list_screen.dart
+++ b/lib/features/photos/screens/parent_photo_list_screen.dart
@@ -1,3 +1,4 @@
+import 'package:aimory_app/features/photos/screens/photo_detail_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:aimory_app/core/const/colors.dart';
 
@@ -50,6 +51,12 @@ class _ParentPhotoListScreenState extends State<ParentPhotoListScreen> {
           }
 
           final data = snapshot.data!;
+          // 임시 사진 URL 리스트 생성
+          final List<String> photos = List.generate(
+            data.count,
+                (index) =>
+            'https://imgnews.pstatic.net/image/056/2025/01/15/0011875678_001_20250115182816671.jpg',
+          );
           return Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
@@ -83,14 +90,32 @@ class _ParentPhotoListScreenState extends State<ParentPhotoListScreen> {
                     ),
                     itemCount: data.count,
                     itemBuilder: (context, index) {
-                      return Container(
-                        decoration: BoxDecoration(
-                          color: LIGHT_GREY_COLOR, // 기본 배경색
-                          image: DecorationImage(
-                            image: NetworkImage(data.profileImageUrl), // 네트워크 이미지 표시
-                            fit: BoxFit.cover,
+
+                      final photoUrl = photos[index];
+                      return GestureDetector(
+                        onTap: () {
+                          // PhotoDetailScreen으로 이동
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => PhotoDetailScreen(
+                                imageUrl: photoUrl,
+                                title: data.name,
+                                date: '2024.05.26. 오후 3:00', // 예제 날짜
+                                role: 'parent', // 부모 역할
+                              ),
+                            ),
+                          );
+                        },
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: LIGHT_GREY_COLOR, // 기본 배경색
+                            image: DecorationImage(
+                              image: NetworkImage(photoUrl), // 네트워크 이미지 표시
+                              fit: BoxFit.cover,
+                            ),
+                            borderRadius: BorderRadius.circular(8.0),
                           ),
-                          borderRadius: BorderRadius.circular(8.0),
                         ),
                       );
                     },

--- a/lib/features/photos/screens/photo_detail_screen.dart
+++ b/lib/features/photos/screens/photo_detail_screen.dart
@@ -1,0 +1,86 @@
+import 'package:aimory_app/core/const/colors.dart';
+import 'package:flutter/material.dart';
+
+class PhotoDetailScreen extends StatelessWidget {
+  final String imageUrl; // 사진 URL
+  final String title; // 제목
+  final String date; // 날짜
+  final String role; // 사용자 역할 (parent/teacher)
+
+  const PhotoDetailScreen({
+    Key? key,
+    required this.imageUrl,
+    required this.title,
+    required this.date,
+    required this.role,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        centerTitle: true,
+        title: Column(
+          children: [
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: Colors.black,
+              ),
+            ),
+            Text(
+              date,
+              style: const TextStyle(
+                fontSize: 12,
+                color: Colors.grey,
+              ),
+            ),
+          ],
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.keyboard_backspace_sharp, color: Colors.black),
+          onPressed: () {
+            Navigator.pop(context); // 이전 화면으로 돌아가기
+          },
+        ),
+      ),
+
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: 16.0,),
+          Expanded(
+            child: Container(
+              margin: const EdgeInsets.symmetric(horizontal: 16.0),
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                // borderRadius: BorderRadius.circular(16.0),
+                image: DecorationImage(
+                  image: NetworkImage(imageUrl),
+                  fit: BoxFit.contain,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10.0),
+          if (role == 'teacher') // 역할이 'teacher'일 때만 삭제 버튼 표시
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.delete_outlined, color: BLACK_COLOR),
+                  onPressed: () {
+                    // 삭제 기능 구현
+                  },
+                ),
+                const SizedBox(width: 16.0),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/photos/screens/teacher_album_screen.dart
+++ b/lib/features/photos/screens/teacher_album_screen.dart
@@ -133,6 +133,7 @@ class _TeacherAlbumScreenState extends State<TeacherAlbumScreen> {
                                 album.count,
                                     (idx) => 'https://imgnews.pstatic.net/image/366/2025/01/15/0001047437_002_20250115110121752.jpg',
                               ),
+                              allPhotos: []
                             ),
                           ),
                         );

--- a/lib/features/photos/screens/teacher_photo_list_screen.dart
+++ b/lib/features/photos/screens/teacher_photo_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:aimory_app/core/const/colors.dart';
+import 'package:aimory_app/features/photos/screens/photo_detail_screen.dart';
 import 'package:flutter/material.dart';
 
 class TeacherPhotoListScreen extends StatelessWidget {
@@ -6,16 +7,24 @@ class TeacherPhotoListScreen extends StatelessWidget {
   final String childName; // 원아 이름
   final int photoCount; // 원아 사진 개수
   final List<String> photos; // 사진 URL 리스트
+  final List<Map<String, dynamic>> allPhotos;
 
   const TeacherPhotoListScreen({
     Key? key,
     required this.childName,
     required this.photoCount,
     required this.photos,
+    required this.allPhotos,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    // 특정 원아의 사진만 필터링
+    final filteredPhotos = allPhotos
+        .where((photo) => photo['childName'] == childName)
+        .map((photo) => photo['photoUrl'] as String)
+        .toList();
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
@@ -67,16 +76,33 @@ class TeacherPhotoListScreen extends StatelessWidget {
                 ),
                 itemCount: photos.length,
                 itemBuilder: (context, index) {
-                  return Container(
-                    decoration: BoxDecoration(
-                      color: LIGHT_GREY_COLOR, // 기본 배경색
-                      image: photos[index].isNotEmpty
-                          ? DecorationImage(
-                        image: AssetImage(photos[index]), // 로컬 이미지 표시
-                        fit: BoxFit.cover,
-                      )
-                          : null, // 사진이 없는 경우 빈 박스
-                      borderRadius: BorderRadius.circular(8.0),
+                  final photoUrl = photos[index];
+                  return GestureDetector(
+                    onTap: () {
+                      // PhotoDetailScreen으로 이동
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => PhotoDetailScreen(
+                            imageUrl: photoUrl,
+                            title: childName,
+                            date: '2024.05.26. 오후 3:00', // 예제 날짜
+                            role: 'teacher', // 역할 전달 (teacher/parent)
+                          ),
+                        ),
+                      );
+                    },
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: LIGHT_GREY_COLOR, // 기본 배경색
+                        image: photoUrl.isNotEmpty
+                            ? DecorationImage(
+                          image: NetworkImage(photoUrl), // 로컬 이미지 표시
+                          fit: BoxFit.cover,
+                        )
+                            : null, // 사진이 없는 경우 빈 박스
+                        borderRadius: BorderRadius.circular(8.0),
+                      ),
                     ),
                   );
                 },


### PR DESCRIPTION
## 💥 연관된 이슈
#43

## 🔨 작업 내용
- 해당 사진 리스트뷰 탭 시 보여지는 이미지 화면 스크린 생성
- 해당 원아 사진첩 리스트뷰 탭 시 스크린 연결

## 👀작업 결과 이미지
![Screen_Recording_20250115_221437_1](https://github.com/user-attachments/assets/5142bf40-c0bb-4018-828f-49138fd70b36)
