### PR TITLE
FEAT(#44): 사진촬영/갤러리 사진 업로드 기능 컴포넌트화 및 스크린 연결

### DIFF
--- a/lib/core/screens/tab_screen.dart
+++ b/lib/core/screens/tab_screen.dart
@@ -60,17 +60,17 @@ class _TabScreenState extends State<TabScreen> {
       body: IndexedStack(
         index: _selectedTabIndex,
         children: [
-          // const TeacherHomeScreen(), // Home Screen
-          // TeacherNoticeListScreen(), // Notice Screen
-          // TeacherNoteListScreen(), // Note Screen
-          // TeacherAlbumScreen(), // Photo Screen
-          // TeacherInfoScreen(), // Info Screen
+          const TeacherHomeScreen(), // Home Screen
+          TeacherNoticeListScreen(), // Notice Screen
+          TeacherNoteListScreen(), // Note Screen
+          TeacherAlbumScreen(), // Photo Screen
+          TeacherInfoScreen(), // Info Screen
 
-          const ParentHomeScreen(),
-          ParentNoticeListScreen(),
-          ParentNoteListScreen(),
-          ParentPhotoListScreen(childId: parentChildId), // 데이터를 직접 전달
-          ParentInfoScreen(),
+          // const ParentHomeScreen(),
+          // ParentNoticeListScreen(),
+          // ParentNoteListScreen(),
+          // ParentPhotoListScreen(childId: parentChildId), // 데이터를 직접 전달
+          // ParentInfoScreen(),
         ],
       ),
       bottomNavigationBar: BottomNavigationBar(

--- a/lib/core/widgets/custom_input_decoration.dart
+++ b/lib/core/widgets/custom_input_decoration.dart
@@ -11,7 +11,7 @@ class CustomInputDecoration {
       filled: true, // 텍스트 필드에 배경색을 활성화
       fillColor: F4_GREY_COLOR, // 활성화된 배경색의 색상
       border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(0), // 테두리의 둥근 정도 설정
+        borderRadius: BorderRadius.circular(10.0), // 테두리의 둥근 정도 설정
         borderSide: BorderSide.none, // 테두리를 제거
       ),
     );

--- a/lib/core/widgets/multi_image_picker.dart
+++ b/lib/core/widgets/multi_image_picker.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+class MultiImagePicker extends StatelessWidget {
+  final Function(List<XFile>) onImagesPicked;
+  final Widget Function(BuildContext, Function()) builder;
+
+  const MultiImagePicker({
+    Key? key,
+    required this.onImagesPicked,
+    required this.builder,
+  }) : super(key: key);
+
+  Future<void> _pickImages(BuildContext context) async {
+    final ImagePicker picker = ImagePicker();
+    try {
+      final List<XFile>? pickedFiles = await picker.pickMultiImage();
+      if (pickedFiles != null) {
+        onImagesPicked(pickedFiles);
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('이미지 선택 중 오류 발생: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return builder(context, () => _pickImages(context));
+  }
+}

--- a/lib/core/widgets/photo_picker.dart
+++ b/lib/core/widgets/photo_picker.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+class PhotoPicker extends StatefulWidget {
+  final void Function(File?) onImagePicked; // 선택된 이미지를 전달하는 콜백
+  final Widget Function(BuildContext, File?) builder; // 사용자 정의 위젯 빌더
+
+  const PhotoPicker({
+    Key? key,
+    required this.onImagePicked,
+    required this.builder,
+  }) : super(key: key);
+
+  @override
+  State<PhotoPicker> createState() => _PhotoPickerState();
+}
+
+class _PhotoPickerState extends State<PhotoPicker> {
+  File? _selectedImage;
+  final ImagePicker _picker = ImagePicker();
+
+  Future<void> _pickImage() async {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.camera),
+                title: const Text('사진 촬영'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  final pickedFile = await _picker.pickImage(
+                    source: ImageSource.camera,
+                  );
+                  if (pickedFile != null) {
+                    setState(() {
+                      _selectedImage = File(pickedFile.path);
+                    });
+                    widget.onImagePicked(_selectedImage);
+                  }
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.photo),
+                title: const Text('갤러리에서 선택'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  final pickedFile = await _picker.pickImage(
+                    source: ImageSource.gallery,
+                  );
+                  if (pickedFile != null) {
+                    setState(() {
+                      _selectedImage = File(pickedFile.path);
+                    });
+                    widget.onImagePicked(_selectedImage);
+                  }
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.close),
+                title: const Text('취소'),
+                onTap: () {
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: _pickImage,
+      child: widget.builder(context, _selectedImage),
+    );
+  }
+}

--- a/lib/features/auth/screens/center_info_insert_screen.dart
+++ b/lib/features/auth/screens/center_info_insert_screen.dart
@@ -1,9 +1,11 @@
+import 'dart:io';
+
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart'; // 날짜 포맷을 위해 추가
-
 import '../../../core/widgets/custom_button.dart';
 import '../../../core/widgets/custom_input_decoration.dart';
+import '../../../core/widgets/photo_picker.dart';
 
 class CenterInfoInsertScreen extends StatefulWidget {
   const CenterInfoInsertScreen({Key? key}) : super(key: key);
@@ -14,6 +16,7 @@ class CenterInfoInsertScreen extends StatefulWidget {
 
 class _CenterInfoInsertScreenState extends State<CenterInfoInsertScreen> {
   final TextEditingController _dateController = TextEditingController();
+  File? _selectedImage;
 
   @override
   void dispose() {
@@ -45,19 +48,28 @@ class _CenterInfoInsertScreenState extends State<CenterInfoInsertScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-
-            // TODO : 카메라/갤러리 연동하여 바꿀 수 있도록
-            SizedBox(
-              height: 120.0,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  CircleAvatar(
+            PhotoPicker(
+              onImagePicked: (image) {
+                setState(() {
+                  _selectedImage = image;
+                });
+              },
+              builder: (context, image) {
+                return Center(
+                  heightFactor: 1.5,
+                  child: CircleAvatar(
                     radius: 40,
                     backgroundColor: Colors.grey,
+                    backgroundImage: image != null ? FileImage(image) : null,
+                    child: image == null
+                        ? const Icon(
+                      Icons.camera_alt,
+                      color: Colors.white,
+                    )
+                        : null,
                   ),
-                ],
-              ),
+                );
+              },
             ),
 
             const SizedBox(height: 16),
@@ -66,7 +78,7 @@ class _CenterInfoInsertScreenState extends State<CenterInfoInsertScreen> {
 
             TextFormField(
               readOnly: true, // 수정 불가능하도록 설정
-              initialValue:  null, // TODO: 유저 이름 데이터 표시
+              initialValue: null, // TODO: 유저 이름 데이터 표시
               decoration: CustomInputDecoration.basic(
                 hintText: '소속을 입력하세요.',
               ),

--- a/lib/features/auth/screens/child_info_insert_screen.dart
+++ b/lib/features/auth/screens/child_info_insert_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:io';
+
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart'; // 날짜 포맷을 위해 추가
 
 import '../../../core/widgets/custom_button.dart';
 import '../../../core/widgets/custom_input_decoration.dart';
+import '../../../core/widgets/photo_picker.dart';
 
 class ChildInfoInsertScreen extends StatefulWidget {
   const ChildInfoInsertScreen({Key? key}) : super(key: key);
@@ -14,6 +17,7 @@ class ChildInfoInsertScreen extends StatefulWidget {
 
 class _ChildInfoInsertScreenState extends State<ChildInfoInsertScreen> {
   final TextEditingController _dateController = TextEditingController();
+  File? _selectedImage;
 
   @override
   void dispose() {
@@ -45,20 +49,30 @@ class _ChildInfoInsertScreenState extends State<ChildInfoInsertScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-
-            // TODO : 카메라/갤러리 연동하여 바꿀 수 있도록
-            SizedBox(
-              height: 120.0,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  CircleAvatar(
+            PhotoPicker(
+              onImagePicked: (image) {
+                setState(() {
+                  _selectedImage = image;
+                });
+              },
+              builder: (context, image) {
+                return Center(
+                  heightFactor: 1.5,
+                  child: CircleAvatar(
                     radius: 40,
                     backgroundColor: Colors.grey,
+                    backgroundImage: image != null ? FileImage(image) : null,
+                    child: image == null
+                        ? const Icon(
+                      Icons.camera_alt,
+                      color: Colors.white,
+                    )
+                        : null,
                   ),
-                ],
-              ),
+                );
+              },
             ),
+
             const SizedBox(height: 16),
             const Text('이름'),
             const SizedBox(height: 8),

--- a/lib/features/auth/screens/info_insert_screen.dart
+++ b/lib/features/auth/screens/info_insert_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:io';
+
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart'; // 날짜 포맷을 위해 추가
 
 import '../../../core/widgets/custom_button.dart';
 import '../../../core/widgets/custom_input_decoration.dart';
+import '../../../core/widgets/photo_picker.dart';
 
 class InfoInsertScreen extends StatefulWidget {
   const InfoInsertScreen({Key? key}) : super(key: key);
@@ -14,6 +17,7 @@ class InfoInsertScreen extends StatefulWidget {
 
 class _InfoInsertScreenState extends State<InfoInsertScreen> {
   final TextEditingController _dateController = TextEditingController();
+  File? _selectedImage;
 
   @override
   void dispose() {
@@ -45,19 +49,28 @@ class _InfoInsertScreenState extends State<InfoInsertScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-
-            // TODO : 카메라/갤러리 연동하여 바꿀 수 있도록
-            SizedBox(
-              height: 120.0,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  CircleAvatar(
+            PhotoPicker(
+              onImagePicked: (image) {
+                setState(() {
+                  _selectedImage = image;
+                });
+              },
+              builder: (context, image) {
+                return Center(
+                  heightFactor: 1.5,
+                  child: CircleAvatar(
                     radius: 40,
                     backgroundColor: Colors.grey,
+                    backgroundImage: image != null ? FileImage(image) : null,
+                    child: image == null
+                        ? const Icon(
+                      Icons.camera_alt,
+                      color: Colors.white,
+                    )
+                        : null,
                   ),
-                ],
-              ),
+                );
+              },
             ),
 
             const SizedBox(height: 16),

--- a/lib/features/notices/screens/notice_insert_screen.dart
+++ b/lib/features/notices/screens/notice_insert_screen.dart
@@ -1,9 +1,13 @@
+import 'dart:io';
+
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart'; // 날짜 포맷을 위해 추가
 
 import '../../../core/widgets/custom_button.dart';
 import '../../../core/widgets/custom_input_decoration.dart';
+import '../../../core/widgets/multi_image_picker.dart';
 
 class NoticeInsertScreen extends StatefulWidget {
   const NoticeInsertScreen({Key? key}) : super(key: key);
@@ -15,11 +19,18 @@ class NoticeInsertScreen extends StatefulWidget {
 class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
   final TextEditingController _dateController = TextEditingController();
   DateTime _selectedDate = DateTime.now();
+  List<File> _selectedImages = [];
 
   @override
   void dispose() {
     _dateController.dispose();
     super.dispose();
+  }
+
+  void _removeImage(int index) {
+    setState(() {
+      _selectedImages.removeAt(index);
+    });
   }
 
   void _openCustomDatePicker(BuildContext context) {
@@ -74,12 +85,10 @@ class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
               ],
             ),
           ),
-
         );
       },
     );
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -101,7 +110,7 @@ class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
           },
         ),
       ),
-      body: Padding(
+      body: SingleChildScrollView(
         padding: const EdgeInsets.all(20.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -140,24 +149,67 @@ class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
               ),
             ),
             const SizedBox(height: 16),
-            const Text('file_name_01.jpg'),
-            const Text('file_name_02.jpg'),
+            if (_selectedImages.isNotEmpty)
+              Wrap(
+                spacing: 8.0,
+                runSpacing: 8.0,
+                children: _selectedImages.asMap().entries.map((entry) {
+                  int index = entry.key;
+                  File image = entry.value;
+                  return Stack(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8.0),
+                        child: Image.file(
+                          image,
+                          width: 100,
+                          height: 100,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      Positioned(
+                        top: 0,
+                        right: 0,
+                        child: GestureDetector(
+                          onTap: () => _removeImage(index),
+                          child: const CircleAvatar(
+                            radius: 10,
+                            backgroundColor: MAIN_YELLOW,
+                            child: Icon(
+                              Icons.close,
+                              color: MAIN_DARK_GREY,
+                              size: 14,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                }).toList(),
+              ),
             const SizedBox(height: 16),
             Row(
               children: [
                 Expanded(
-                  child: ElevatedButton(
-                    onPressed: () {},
-                    style: ElevatedButton.styleFrom(
-                      elevation: 0,
-                      padding: const EdgeInsets.symmetric(vertical: 12.0),
-                      backgroundColor: MAIN_YELLOW,
-                      foregroundColor: BLACK_COLOR,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10.0),
+                  child: MultiImagePicker(
+                    onImagesPicked: (pickedFiles) {
+                      setState(() {
+                        _selectedImages.addAll(pickedFiles.map((file) => File(file.path)));
+                      });
+                    },
+                    builder: (context, pickImages) => ElevatedButton(
+                      onPressed: pickImages,
+                      style: ElevatedButton.styleFrom(
+                        elevation: 0,
+                        padding: const EdgeInsets.symmetric(vertical: 12.0),
+                        backgroundColor: MAIN_YELLOW,
+                        foregroundColor: BLACK_COLOR,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10.0),
+                        ),
                       ),
+                      child: const Text('사진추가'),
                     ),
-                    child: const Text('사진추가'),
                   ),
                 ),
                 const SizedBox(width: 16),
@@ -178,7 +230,7 @@ class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
                 ),
               ],
             ),
-            const Spacer(),
+            const SizedBox(height: 16),
             CustomButton(
               text: '등록하기',
               onPressed: () {

--- a/lib/features/photos/screens/teacher_album_screen.dart
+++ b/lib/features/photos/screens/teacher_album_screen.dart
@@ -1,6 +1,8 @@
 import 'package:aimory_app/features/photos/screens/teacher_photo_list_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import '../../../core/const/colors.dart';
+import '../../../core/widgets/multi_image_picker.dart';
 import '../models/album_model.dart';
 import '../services/album_service.dart';
 
@@ -13,6 +15,8 @@ class TeacherAlbumScreen extends StatefulWidget {
 
 class _TeacherAlbumScreenState extends State<TeacherAlbumScreen> {
   late Future<List<Album>> albums;
+  final List<XFile> _selectedPhotos = [];
+  final ImagePicker _picker = ImagePicker();
 
   @override
   void initState() {
@@ -46,48 +50,72 @@ class _TeacherAlbumScreenState extends State<TeacherAlbumScreen> {
     ];
   }
 
+  Future<void> _pickMultipleImages() async {
+    try {
+      final List<XFile>? pickedFiles = await _picker.pickMultiImage();
+      if (pickedFiles != null) {
+        setState(() {
+          _selectedPhotos.addAll(pickedFiles);
+        });
+        // 선택된 파일 로그 출력
+        for (var file in pickedFiles) {
+          print('선택된 파일: ${file.path}');
+        }
+      }
+    } catch (e) {
+      print('이미지 선택 중 오류 발생: $e');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
-        children: [
-          Container(
-            color: F4_GREY_COLOR,
-            padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end, // 버튼을 오른쪽 정렬
-              children: [
-                TextButton.icon(
-                  onPressed: () {
-                    // Navigator.push(
-                    //   context,
-                    //   MaterialPageRoute(builder: (context) => const PhotoInsertScreen()),
-                    // );
-                  }, // 사진 추가 버튼 기능
-                  label: const Text(
-                    "사진 추가하기",
-                    style: TextStyle(
-                      color: DARK_GREY_COLOR,
-                      fontSize: 14,
-                    ),
-                  ),
-                  style: TextButton.styleFrom(
-                    backgroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(20),
-                      side: BorderSide(
-                        color: MID_GREY_COLOR, // 테두리 색상
-                        width: 1, // 테두리 두께
+      body: SingleChildScrollView( // 전체 화면 스크롤 가능하도록 추가
+        child: Column(
+          children: [
+            Container(
+              color: F4_GREY_COLOR,
+              padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end, // 버튼을 오른쪽 정렬
+                children: [
+                  MultiImagePicker(
+                    onImagesPicked: (pickedFiles) {
+                      setState(() {
+                        _selectedPhotos.addAll(pickedFiles);
+                      });
+                      print('선택된 파일 목록:');
+                      for (var file in pickedFiles) {
+                        print(file.path); // 파일 경로 출력
+                      }
+                      print('총 선택된 파일 개수: ${pickedFiles.length}'); // 파일 개수 출력
+                    },
+                    builder: (context, pickImages) => TextButton.icon(
+                      onPressed: pickImages, // 사진 추가 버튼 기능
+                      label: const Text(
+                        "사진 추가하기",
+                        style: TextStyle(
+                          color: DARK_GREY_COLOR,
+                          fontSize: 14,
+                        ),
                       ),
+                      style: TextButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(20),
+                          side: BorderSide(
+                            color: MID_GREY_COLOR, // 테두리 색상
+                            width: 1, // 테두리 두께
+                          ),
+                        ),
+                      ),
+                      icon: Icon(Icons.add, color: DARK_GREY_COLOR), // 아이콘 추가
                     ),
                   ),
-                  icon: Icon(Icons.add, color: DARK_GREY_COLOR), // 아이콘 추가
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-          Expanded(
-            child: FutureBuilder<List<Album>>(
+            FutureBuilder<List<Album>>(
               future: albums,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
@@ -110,6 +138,8 @@ class _TeacherAlbumScreenState extends State<TeacherAlbumScreen> {
                 ];
 
                 return GridView.builder(
+                  physics: const NeverScrollableScrollPhysics(), // 내부 스크롤 비활성화
+                  shrinkWrap: true,
                   padding: const EdgeInsets.all(16.0),
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 2, // 한 줄에 두 개의 아이템
@@ -127,13 +157,13 @@ class _TeacherAlbumScreenState extends State<TeacherAlbumScreen> {
                           context,
                           MaterialPageRoute(
                             builder: (context) => TeacherPhotoListScreen(
-                              childName: album.name,
-                              photoCount: album.count,
-                              photos: List.generate(
-                                album.count,
-                                    (idx) => 'https://imgnews.pstatic.net/image/366/2025/01/15/0001047437_002_20250115110121752.jpg',
-                              ),
-                              allPhotos: []
+                                childName: album.name,
+                                photoCount: album.count,
+                                photos: List.generate(
+                                  album.count,
+                                      (idx) => 'https://imgnews.pstatic.net/image/366/2025/01/15/0001047437_002_20250115110121752.jpg',
+                                ),
+                                allPhotos: []
                             ),
                           ),
                         );
@@ -168,8 +198,8 @@ class _TeacherAlbumScreenState extends State<TeacherAlbumScreen> {
                 );
               },
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,6 +174,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -246,6 +254,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+3"
   fixnum:
     dependency: transitive
     description:
@@ -283,6 +323,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.24"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -357,6 +405,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: b6951e25b795d053a6ba03af5f710069c99349de9341af95155d52665cb4607c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.9"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: b62d34a506e12bb965e824b6db4fbf709ee4589cf5d3e99b45ab2287b008ee0c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+20"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "98f50d6b9f294c8ba35e25cc0d13b04bfddd25dbc8d32fa9d566a6572f2c081c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.12"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   json_serializable: ^6.7.1 # JSON 처리
   flutter_native_splash: ^2.4.4
   intl: ^0.20.1
+  image_picker: ^0.8.7+3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 💥 연관된 이슈
#44

## 🔨 작업 내용
- 단일 선택 사진 업로드 기능 컴포넌트화 위젯 생성
- 다중 선택 사진 업로드 기능 컴포넌트화 위젯 생성
- 사진 선택 기능 필요한 스크린들에 기능 구현

## 👀작업 결과 이미지
[단일 선택 기능]
![Screen_Recording_20250116_201106_2](https://github.com/user-attachments/assets/3b97b73b-8384-47b2-8276-f7f46d492904)
[다중 선택 기능]
![Screen_Recording_20250116_195453_1](https://github.com/user-attachments/assets/211ed201-4125-4f1f-bfa1-4cc85e2d5ae1)
