### PR TITLE
FEAT(#48): 학부모 메인화면 공지사항/사진첩 연결

### DIFF
--- a/lib/core/screens/tab_screen.dart
+++ b/lib/core/screens/tab_screen.dart
@@ -78,17 +78,17 @@ class _TabScreenState extends State<TabScreen> with SingleTickerProviderStateMix
       body: TabBarView(
         controller: _tabController, // TabController 연결
         children: [
-          TeacherHomeScreen(), // Home Screen
-          TeacherNoticeListScreen(), // Notice Screen
-          TeacherNoteListScreen(), // Note Screen
-          TeacherAlbumScreen(), // Photo Screen
-          TeacherInfoScreen(), // Info Screen
+          // TeacherHomeScreen(), // Home Screen
+          // TeacherNoticeListScreen(), // Notice Screen
+          // TeacherNoteListScreen(), // Note Screen
+          // TeacherAlbumScreen(), // Photo Screen
+          // TeacherInfoScreen(), // Info Screen
 
-          // ParentHomeScreen(),
-          // ParentNoticeListScreen(),
-          // ParentNoteListScreen(),
-          // ParentPhotoListScreen(childId: parentChildId), // 데이터를 직접 전달
-          // ParentInfoScreen(),
+          ParentHomeScreen(),
+          ParentNoticeListScreen(),
+          ParentNoteListScreen(),
+          ParentPhotoListScreen(childId: parentChildId), // 데이터를 직접 전달
+          ParentInfoScreen(),
         ],
       ),
 

--- a/lib/features/auth/screens/child_info_update_screen.dart
+++ b/lib/features/auth/screens/child_info_update_screen.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:aimory_app/core/const/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart'; // 날짜 포맷을 위해 추가
+
+import '../../../core/widgets/custom_button.dart';
+import '../../../core/widgets/custom_input_decoration.dart';
+import '../../../core/widgets/photo_picker.dart';
+
+class ChildInfoUpdateScreen extends StatefulWidget {
+  const ChildInfoUpdateScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ChildInfoUpdateScreen> createState() => _ChildInfoUpdateScreenState();
+}
+
+class _ChildInfoUpdateScreenState extends State<ChildInfoUpdateScreen> {
+  final TextEditingController _dateController = TextEditingController();
+  File? _selectedImage;
+
+  @override
+  void dispose() {
+    _dateController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        centerTitle: true,
+        title: const Text(
+          '아이 정보 수정',
+          style: TextStyle(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.keyboard_backspace_sharp),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            PhotoPicker(
+              onImagePicked: (image) {
+                setState(() {
+                  _selectedImage = image;
+                });
+              },
+              builder: (context, image) {
+                return Center(
+                  heightFactor: 1.5,
+                  child: CircleAvatar(
+                    radius: 40,
+                    backgroundColor: Colors.grey,
+                    backgroundImage: image != null ? FileImage(image) : null,
+                    child: image == null
+                        ? const Icon(
+                      Icons.camera_alt,
+                      color: Colors.white,
+                    )
+                        : null,
+                  ),
+                );
+              },
+            ),
+
+            const SizedBox(height: 16),
+            const Text('이름'),
+            const SizedBox(height: 8),
+
+            TextFormField(
+              readOnly: true, // 수정 불가능하도록 설정
+              initialValue:  null, // TODO: 유저 이름 데이터 표시
+              decoration: CustomInputDecoration.basic(
+                hintText: '이름을 입력하세요.',
+              ),
+            ),
+            // TODO : 달력 위젯 연동
+            const SizedBox(height: 16),
+            const Text('생년월일'),
+            const SizedBox(height: 8),
+            TextFormField(
+              obscureText: true,
+              decoration: CustomInputDecoration.basic(
+                hintText: '생년월일을 입력하세요.',
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            const Text('소속'),
+            const SizedBox(height: 8),
+
+            TextFormField(
+              readOnly: true, // 수정 불가능하도록 설정
+              initialValue:  null, // TODO: 유저 이름 데이터 표시
+              decoration: CustomInputDecoration.basic(
+                hintText: '소속을 입력하세요.',
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text('반'),
+            const SizedBox(height: 8),
+            TextFormField(
+              obscureText: true,
+              decoration: CustomInputDecoration.basic(
+                hintText: '해당 반을 입력하세요.',
+              ),
+            ),
+            const SizedBox(height: 24),
+            CustomButton(
+              text: '등록하기',
+              onPressed: () {
+                // TODO : 클릭 시 이벤트
+                print('등록하기 버튼 클릭');
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/appbar/parent_home_app_bar.dart
+++ b/lib/features/home/appbar/parent_home_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../core/const/colors.dart';
+import '../../auth/screens/child_info_update_screen.dart';
 
 class ParentHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
   const ParentHomeAppBar({Key? key}) : super(key: key);
@@ -150,7 +151,12 @@ class ParentHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
                               Align(
                                 alignment: Alignment.centerLeft,
                                 child: TextButton.icon(
-                                  onPressed: () {}, // 자세히 보기 버튼 기능
+                                  onPressed: () {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(builder: (context) => ChildInfoUpdateScreen()),
+                                    );
+                                  }, // 자세히 보기 버튼 기능
                                   icon: const Icon(Icons.add, size: 14, color: Colors.white),
                                   label: const Text(
                                     "자세히 보기",

--- a/lib/features/home/screens/parent_home_screen.dart
+++ b/lib/features/home/screens/parent_home_screen.dart
@@ -22,6 +22,12 @@ class ParentHomeScreen extends StatelessWidget {
       ),
     );
 
+    // 우리아이 앨범 샘플 데이터를 정의
+    final List<String> allPhotos = List.generate(
+      9,
+          (index) => 'https://static.rocketpunch.com/images/jibmusil/index/pc-section5-mood1-min.jpg',
+    );
+
     return Scaffold(
       backgroundColor: Colors.white,
       body: Column(
@@ -295,13 +301,20 @@ class ParentHomeScreen extends StatelessWidget {
                           physics: const NeverScrollableScrollPhysics(),
                           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                             crossAxisCount: 3,
-                            crossAxisSpacing: 8,
-                            mainAxisSpacing: 8,
+                            crossAxisSpacing: 8.0,
+                            mainAxisSpacing: 8.0,
                           ),
-                          itemCount: 9, // 샘플 이미지 개수
+                          itemCount: allPhotos.length, // 샘플 이미지 개수
                           itemBuilder: (context, index) {
-                            return Container(
-                              color: BORDER_GREY_COLOR, // 샘플 이미지
+                            final photoUrl = allPhotos[index];
+                            return Container(decoration: BoxDecoration(
+                              color: LIGHT_GREY_COLOR,
+                              image: DecorationImage(
+                                image: NetworkImage(photoUrl),
+                                fit: BoxFit.cover,
+                              ),
+                              borderRadius: BorderRadius.circular(8.0),
+                            ),
                             );
                           },
                         ),

--- a/lib/features/home/screens/parent_home_screen.dart
+++ b/lib/features/home/screens/parent_home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
+import '../../../core/screens/tab_screen.dart';
 import '../appbar/parent_home_app_bar.dart';
 import '../appbar/teacher_home_app_bar.dart';
 
@@ -31,26 +32,30 @@ class ParentHomeScreen extends StatelessWidget {
                           children: [
                             // 전체 알림장
                             Text(
-                              "전체 알림장",
+                              "공지사항",
                               style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
                             ),
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.start,
-                              children: [
-                                Text(
-                                  "더보기",
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.w300,
+                            TextButton(
+                              onPressed: () {
+                                TabScreen.tabScreenKey.currentState?.changeTab(1); // "공지사항" 탭으로 이동
+                              },
+                              child: Row(
+                                children: [
+                                  Text(
+                                    "더보기",
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w300,
+                                      color: MAIN_DARK_GREY,
+                                    ),
+                                  ),
+                                  Icon(
+                                    Icons.chevron_right,
+                                    size: 20,
                                     color: MAIN_DARK_GREY,
                                   ),
-                                ),
-                                Icon(
-                                  Icons.chevron_right,
-                                  size: 20,
-                                  color: MAIN_DARK_GREY,
-                                ),
-                              ],
+                                ],
+                              ),
                             ),
                           ],
                         ),
@@ -120,22 +125,27 @@ class ParentHomeScreen extends StatelessWidget {
                               "우리아이 알림장",
                               style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
                             ),
-                            Row(
-                              children: [
-                                Text(
-                                  "더보기",
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.w300,
+                            TextButton(
+                              onPressed: () {
+                                TabScreen.tabScreenKey.currentState?.changeTab(2); // "알림장" 탭으로 이동
+                              },
+                              child: Row(
+                                children: [
+                                  Text(
+                                    "더보기",
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w300,
+                                      color: MAIN_DARK_GREY,
+                                    ),
+                                  ),
+                                  Icon(
+                                    Icons.chevron_right,
+                                    size: 20,
                                     color: MAIN_DARK_GREY,
                                   ),
-                                ),
-                                Icon(
-                                  Icons.chevron_right,
-                                  size: 20,
-                                  color: MAIN_DARK_GREY,
-                                ),
-                              ],
+                                ],
+                              ),
                             ),
                           ],
                         ),
@@ -230,23 +240,27 @@ class ParentHomeScreen extends StatelessWidget {
                               "우리아이 앨범",
                               style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
                             ),
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.start,
-                              children: [
-                                Text(
-                                  "더보기",
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.w300,
+                            TextButton(
+                              onPressed: () {
+                                TabScreen.tabScreenKey.currentState?.changeTab(3); // "사진첩" 탭으로 이동
+                              },
+                              child: Row(
+                                children: [
+                                  Text(
+                                    "더보기",
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w300,
+                                      color: MAIN_DARK_GREY,
+                                    ),
+                                  ),
+                                  Icon(
+                                    Icons.chevron_right,
+                                    size: 20,
                                     color: MAIN_DARK_GREY,
                                   ),
-                                ),
-                                Icon(
-                                  Icons.chevron_right,
-                                  size: 20,
-                                  color: MAIN_DARK_GREY,
-                                ),
-                              ],
+                                ],
+                              ),
                             ),
                           ],
                         ),

--- a/lib/features/home/screens/parent_home_screen.dart
+++ b/lib/features/home/screens/parent_home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:aimory_app/core/const/colors.dart';
+import 'package:aimory_app/features/notes/screens/parent_note_detail_screen.dart';
 import 'package:flutter/material.dart';
 import '../../../core/screens/tab_screen.dart';
+import '../../notes/models/note_model.dart';
 import '../../notices/models/notice_model.dart';
 import '../../notices/screens/parent_notice_detail_screen.dart';
 import '../appbar/parent_home_app_bar.dart';
@@ -11,6 +13,7 @@ class ParentHomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+
     final List<Notice> noticeItems = List.generate(
       3, // 3개의 샘플 데이터만 표시
           (index) => Notice(
@@ -19,6 +22,17 @@ class ParentHomeScreen extends StatelessWidget {
         description:
         '오늘 우리 채아는 오전 간식을 아주 잘 먹고 나서 활기차게 놀이를 즐기며 시간을 보냈어요.',
         imageUrl: 'assets/img/notice_img_sample.jpg',
+      ),
+    );
+
+    final List<Note> noteItems = List.generate(
+      10, // 3개의 샘플 데이터만 표시
+          (index) => Note(
+        name: '이채아',
+        date: '2025.01.0${index + 1}',
+        description:
+        '오늘 우리 채아는 오전 간식을 아주 잘 먹고 나서 활기차게 놀이를 즐기며 시간을 보냈어요.',
+        imageUrl: 'assets/img/girl_sample.jpg',
       ),
     );
 
@@ -187,68 +201,81 @@ class ParentHomeScreen extends StatelessWidget {
                           height: 200, // 높이 제한
                           child: ListView.builder(
                             scrollDirection: Axis.horizontal,
-                            itemCount: 5,
+                            itemCount: noteItems.length,
                             itemBuilder: (context, index) {
-                              return Padding(
-                                padding: const EdgeInsets.only(right: 16.0),
-                                child: Card(
-                                  elevation: 0,
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(16),
-                                  ),
-                                  child: Container(
-                                    decoration: BoxDecoration(
-                                      color: Colors.white,
-                                      borderRadius: BorderRadius.circular(12),
-                                      border: Border.all(color: BORDER_GREY_COLOR, width: 1),
+                              final note = noteItems[index];
+                              return GestureDetector(
+                                onTap: () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                        builder: (context) =>
+                                            ParentNoteDetailScreen(note: note),
                                     ),
-                                    width: 200, // 카드 너비
-                                    padding: const EdgeInsets.all(16),
-                                    child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        Row(
+                                  );
+                                },
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(right: 16.0),
+                                    child: Card(
+                                      elevation: 0,
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(16),
+                                      ),
+                                      child: Container(
+                                        decoration: BoxDecoration(
+                                          color: Colors.white,
+                                          borderRadius: BorderRadius.circular(12),
+                                          border: Border.all(color: BORDER_GREY_COLOR, width: 1),
+                                        ),
+                                        width: 200, // 카드 너비
+                                        padding: const EdgeInsets.all(16),
+                                        child: Column(
+                                          crossAxisAlignment: CrossAxisAlignment.start,
                                           children: [
-                                            CircleAvatar(
-                                              radius: 24,
-                                              backgroundImage: AssetImage('assets/img/girl_sample.jpg'), // 샘플 이미지
-                                            ),
-                                            const SizedBox(width: 12),
-                                            Column(
-                                              crossAxisAlignment: CrossAxisAlignment.start,
+                                            Row(
                                               children: [
-                                                Text(
-                                                  "이채아",
-                                                  style: TextStyle(
-                                                    fontSize: 16,
-                                                    fontWeight: FontWeight.w700,
-                                                  ),
+                                                CircleAvatar(
+                                                  radius: 24,
+                                                  backgroundImage: AssetImage(note.imageUrl), // 샘플 이미지
                                                 ),
-                                                Text(
-                                                  "해바라기 반",
-                                                  style: TextStyle(
-                                                    fontSize: 14,
-                                                    color: MAIN_DARK_GREY,
-                                                  ),
+                                                const SizedBox(width: 12),
+                                                Column(
+                                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                                  children: [
+                                                    Text(
+                                                      note.name,
+                                                      style: TextStyle(
+                                                        fontSize: 16,
+                                                        fontWeight: FontWeight.w700,
+                                                      ),
+                                                    ),
+                                                    Text(
+                                                      note.date,
+                                                      style: TextStyle(
+                                                        fontSize: 14,
+                                                        color: MAIN_DARK_GREY,
+                                                      ),
+                                                    ),
+                                                  ],
                                                 ),
                                               ],
                                             ),
+                                            const SizedBox(height: 16),
+                                            Divider(), // 구분선
+                                            const SizedBox(height: 8),
+                                            Text(
+                                              note.description,
+                                              style: TextStyle(fontSize: 14),
+                                              maxLines: 3,
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
                                           ],
                                         ),
-                                        const SizedBox(height: 16),
-                                        Divider(), // 구분선
-                                        const SizedBox(height: 8),
-                                        Text(
-                                          "오늘 우리 채아는 오전 간식을 아주 잘 먹고 나서 활기차게 놀이를 즐기며 시간을 보냈습니다.",
-                                          style: TextStyle(fontSize: 14),
-                                          maxLines: 3,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ],
+                                      ),
                                     ),
                                   ),
-                                ),
                               );
+
                             },
                           ),
                         ),

--- a/lib/features/home/screens/parent_home_screen.dart
+++ b/lib/features/home/screens/parent_home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
 import '../../../core/screens/tab_screen.dart';
+import '../../notices/models/notice_model.dart';
+import '../../notices/screens/parent_notice_detail_screen.dart';
 import '../appbar/parent_home_app_bar.dart';
 import '../appbar/teacher_home_app_bar.dart';
 
@@ -9,6 +11,17 @@ class ParentHomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final List<Notice> noticeItems = List.generate(
+      3, // 3개의 샘플 데이터만 표시
+          (index) => Notice(
+        name: '원장 $index',
+        date: '2025.01.0${index + 1}',
+        description:
+        '오늘 우리 채아는 오전 간식을 아주 잘 먹고 나서 활기차게 놀이를 즐기며 시간을 보냈어요.',
+        imageUrl: 'assets/img/notice_img_sample.jpg',
+      ),
+    );
+
     return Scaffold(
       backgroundColor: Colors.white,
       body: Column(
@@ -30,7 +43,7 @@ class ParentHomeScreen extends StatelessWidget {
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            // 전체 알림장
+                            // 공지사항
                             Text(
                               "공지사항",
                               style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
@@ -72,26 +85,38 @@ class ParentHomeScreen extends StatelessWidget {
                             padding: EdgeInsets.zero,
                             shrinkWrap: true,
                             physics: const NeverScrollableScrollPhysics(),
-                            itemCount: 3, // 샘플 데이터 개수
+                            itemCount: noticeItems.length, // 데이터 개수
                             itemBuilder: (context, index) {
-                              return Container(
-                                margin: const EdgeInsets.all(0), // 카드 외부 여백
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(12),
-                                  color: Colors.white, // 배경색
-                                ),
-                                child: Column(
-                                  children: [
-                                    ListTile(
-                                      title: Text("공지사항 제목 $index"),
-                                      subtitle: Text("2024.05.26"),
+                              final notice = noticeItems[index];
+                              return GestureDetector(
+                                onTap: () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) =>
+                                          ParentNoticeDetailScreen(notice: notice),
                                     ),
-                                    Container(
-                                      margin: EdgeInsets.symmetric(horizontal: 10.0),
-                                      height: 1,
-                                      color: BORDER_GREY_COLOR,
-                                    ),
-                                  ],
+                                  );
+                                },
+                                child: Container(
+                                  margin: const EdgeInsets.all(0), // 카드 외부 여백
+                                  decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(12),
+                                    color: Colors.white, // 배경색
+                                  ),
+                                  child: Column(
+                                    children: [
+                                      ListTile(
+                                        title: Text(notice.name),
+                                        subtitle: Text(notice.date),
+                                      ),
+                                      Container(
+                                        margin: EdgeInsets.symmetric(horizontal: 10.0),
+                                        height: 1,
+                                        color: BORDER_GREY_COLOR,
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               );
                             },

--- a/lib/features/home/screens/teacher_home_screen.dart
+++ b/lib/features/home/screens/teacher_home_screen.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 import '../../../core/screens/tab_screen.dart';
 import '../../notices/models/notice_model.dart';
 import '../../notices/screens/teacher_notice_detail_screen.dart';
-import '../../notices/screens/teacher_notice_list_screen.dart';
-import '../../photos/screens/teacher_album_screen.dart';
 import '../appbar/teacher_home_app_bar.dart';
 
 class TeacherHomeScreen extends StatelessWidget {


### PR DESCRIPTION
## 💥 연관된 이슈
#48

## 🔨 작업 내용
- 상단 '자세히보기' 버튼 내 정보 스크린으로 연결
- 메인화면 공지사항 리스트뷰 연결
- 메인화면 알림장 리스트뷰 연결
- 메인화면 사진첩 리스트뷰 연결
- 더보기 버튼 해당 스크린으로 연결

## 👀작업 결과 이미지

[리스트뷰 연결]
![Screen_Recording_20250120_191900_1](https://github.com/user-attachments/assets/211acf49-6de3-4a2f-bf41-f26c4193a519)

[더보기 버튼 탭 이동 연결]
![Screen_Recording_20250120_191841_1](https://github.com/user-attachments/assets/3b7bc95e-be69-4afa-b6e5-ef0653593154)

