### PR TITLE
FEAT(#55): 부모 검색스크린 생성 및 메인 아이콘과 연결

### DIFF
--- a/lib/features/home/appbar/parent_home_app_bar.dart
+++ b/lib/features/home/appbar/parent_home_app_bar.dart
@@ -1,3 +1,4 @@
+import 'package:aimory_app/features/search/screen/parent_search_screen.dart';
 import 'package:flutter/material.dart';
 import '../../../core/const/colors.dart';
 import '../../auth/screens/child_info_update_screen.dart';
@@ -33,7 +34,12 @@ class ParentHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
                 Row(
                   children: [
                     IconButton(
-                      onPressed: () {}, // 알림 버튼 기능
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (context) => ParentSearchScreen()),
+                        );
+                      }, // 알림 버튼 기능
                       icon: const Icon(
                         Icons.search_outlined,
                         size: 30,

--- a/lib/features/search/screen/parent_search_screen.dart
+++ b/lib/features/search/screen/parent_search_screen.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/const/colors.dart';
+
+class ParentSearchScreen extends StatefulWidget {
+
+  @override
+  _ParentSearchScreenState createState() => _ParentSearchScreenState();
+}
+
+class _ParentSearchScreenState extends State<ParentSearchScreen> {
+  TextEditingController _searchController = TextEditingController();
+  // String? _resultText = '지아는 12월 7일에 돈가스를 맛있게 먹었습니다.';
+  String? _resultText;
+
+  void _onSearch() {
+    setState(() {
+      _resultText = "${_searchController.text}에 대한 정보를 찾았습니다!";
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: MAIN_YELLOW,
+        centerTitle: true,
+        title: const Text(
+          'AI 검색',
+          style: TextStyle(
+            fontSize: 20.0,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.keyboard_backspace),
+          onPressed: () {
+            Navigator.pop(context, false); // 뒤로가기 시 삭제되지 않음을 반환
+          },
+        ),
+      ),
+      body: Container(
+        decoration: BoxDecoration(
+          color: MAIN_YELLOW,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(height: 030),
+              Text(
+                '우리 아이 어린이집 생활\n쉽게 검색하세요.',
+                style: TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              SizedBox(height: 20),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _searchController,
+                      decoration: InputDecoration(
+                        filled: true,
+                        fillColor: Colors.white,
+                        hintText: '12월 7일 지아가 먹은 식단 알려줘',
+                        border: OutlineInputBorder(
+                          borderSide: BorderSide(
+                            color: LIGHT_GREY_COLOR, // 테두리 색상
+                            width: 1.0, // 테두리 두께
+                          ),
+                          borderRadius: BorderRadius.circular(30.0),
+                        ),
+                        suffixIcon: IconButton(
+                          onPressed: _onSearch,
+                          icon: Icon(Icons.search),
+                          color: LIGHT_GREY_COLOR,
+                          iconSize: 30,
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: 8),
+
+                ],
+              ),
+              if (_resultText != null) ...[
+                SizedBox(height: 20),
+                Text(
+                  '답변',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                SizedBox(height: 10),
+                Container(
+                  padding: EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: MAIN_LIGHT_YELLOW,
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  child: Text(
+                    _resultText!,
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+
+    );
+  }
+}


### PR DESCRIPTION
 ## 💥 연관된 이슈
#55

## 🔨 작업 내용
- 검색 스크린 UI 구현
- 검색 스크린 내 appBar 구현(뒤로가기 버튼 포함)
- 메인 AppBar 검색 아이콘 탭 시 이동 구현

## 👀작업 결과 이미지
![Screen_Recording_20250121_231241_1](https://github.com/user-attachments/assets/0db0a471-a827-4ce7-a00a-d2a4a8033991)

