### PR TITLE
FEAT(#61): UI 수정사항 반영 건

### DIFF
--- a/lib/core/screens/tab_screen.dart
+++ b/lib/core/screens/tab_screen.dart
@@ -78,17 +78,17 @@ class _TabScreenState extends State<TabScreen> with SingleTickerProviderStateMix
       body: TabBarView(
         controller: _tabController, // TabController 연결
         children: [
-          // TeacherHomeScreen(), // Home Screen
-          // TeacherNoticeListScreen(), // Notice Screen
-          // TeacherNoteListScreen(), // Note Screen
-          // TeacherAlbumScreen(), // Photo Screen
-          // TeacherInfoScreen(), // Info Screen
+          TeacherHomeScreen(), // Home Screen
+          TeacherNoticeListScreen(), // Notice Screen
+          TeacherNoteListScreen(), // Note Screen
+          TeacherAlbumScreen(), // Photo Screen
+          TeacherInfoScreen(), // Info Screen
 
-          ParentHomeScreen(),
-          ParentNoticeListScreen(),
-          ParentNoteListScreen(),
-          ParentPhotoListScreen(childId: parentChildId), // 데이터를 직접 전달
-          ParentInfoScreen(),
+          // ParentHomeScreen(),
+          // ParentNoticeListScreen(),
+          // ParentNoteListScreen(),
+          // ParentPhotoListScreen(childId: parentChildId), // 데이터를 직접 전달
+          // ParentInfoScreen(),
         ],
       ),
 

--- a/lib/features/home/screens/parent_home_screen.dart
+++ b/lib/features/home/screens/parent_home_screen.dart
@@ -17,7 +17,7 @@ class ParentHomeScreen extends StatelessWidget {
     final List<Notice> noticeItems = List.generate(
       3, // 3개의 샘플 데이터만 표시
           (index) => Notice(
-        name: '원장 $index',
+        title: '제목입니다. $index',
         date: '2025.01.0${index + 1}',
         description:
         '오늘 우리 채아는 오전 간식을 아주 잘 먹고 나서 활기차게 놀이를 즐기며 시간을 보냈어요.',
@@ -127,7 +127,7 @@ class ParentHomeScreen extends StatelessWidget {
                                   child: Column(
                                     children: [
                                       ListTile(
-                                        title: Text(notice.name),
+                                        title: Text(notice.title),
                                         subtitle: Text(notice.date),
                                       ),
                                       Container(

--- a/lib/features/home/screens/teacher_home_screen.dart
+++ b/lib/features/home/screens/teacher_home_screen.dart
@@ -14,7 +14,7 @@ class TeacherHomeScreen extends StatelessWidget {
     final List<Notice> noticeItems = List.generate(
       3, // 3개의 샘플 데이터만 표시
           (index) => Notice(
-        name: '원장 $index',
+        title: '제목입니다. $index',
         date: '2025.01.0${index + 1}',
         description:
         '오늘 우리 채아는 오전 간식을 아주 잘 먹고 나서 활기차게 놀이를 즐기며 시간을 보냈어요.',
@@ -114,7 +114,7 @@ class TeacherHomeScreen extends StatelessWidget {
                                   child: Column(
                                     children: [
                                       ListTile(
-                                        title: Text(notice.name),
+                                        title: Text(notice.title),
                                         subtitle: Text(notice.date),
                                       ),
                                       Container(

--- a/lib/features/notes/screens/note_insert_screen.dart
+++ b/lib/features/notes/screens/note_insert_screen.dart
@@ -19,11 +19,20 @@ class _NoteInsertScreenState extends State<NoteInsertScreen> {
   final TextEditingController _dateController = TextEditingController();
   DateTime _selectedDate = DateTime.now();
   List<File> _selectedImages = [];
+  File? _previewImage;
+  bool _showPreviewImage = false; // 이미지 표시 여부
 
   @override
   void dispose() {
     _dateController.dispose();
     super.dispose();
+  }
+
+  void _removePreviewImage() {
+    setState(() {
+      _previewImage = null;
+      _showPreviewImage = false;
+    });
   }
 
   void _removeImage(int index) {
@@ -119,7 +128,7 @@ class _NoteInsertScreenState extends State<NoteInsertScreen> {
                 Expanded(
                   child: DropdownButtonFormField<String>(
                     decoration: CustomInputDecoration.basic(
-                      hintText: '반분류',
+                      hintText: '원아명',
                     ),
                     items: const [
                       DropdownMenuItem(value: 'option1', child: Text('Option 1')),
@@ -187,6 +196,71 @@ class _NoteInsertScreenState extends State<NoteInsertScreen> {
                   );
                 }).toList(),
               ),
+
+            if (_showPreviewImage && _previewImage == null)
+              Stack(
+                children: [
+                  Container(
+                    width: double.infinity,
+                    height: 200,
+                    color: Colors.grey.shade300,
+                    child: Image.asset(
+                      'assets/img/notice_img_sample.jpg',
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: GestureDetector(
+                      onTap: _removePreviewImage,
+                      child: const CircleAvatar(
+                        radius: 14,
+                        backgroundColor: MAIN_YELLOW,
+                        child: Icon(
+                          Icons.close,
+                          color: MAIN_DARK_GREY,
+                          size: 16,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+
+            if (_showPreviewImage && _previewImage != null)
+              Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8.0),
+                    child: Container(
+                      width: double.infinity,
+                      height: 200,
+                      color: Colors.grey.shade300, // 이미지 없을 시 색상 채우기
+                      child: Image.file(
+                        _previewImage!,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: GestureDetector(
+                      onTap: _removePreviewImage,
+                      child: const CircleAvatar(
+                        radius: 14,
+                        backgroundColor: MAIN_YELLOW,
+                        child: Icon(
+                          Icons.close,
+                          color: MAIN_DARK_GREY,
+                          size: 16,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             const SizedBox(height: 16),
             Row(
               children: [
@@ -215,7 +289,13 @@ class _NoteInsertScreenState extends State<NoteInsertScreen> {
                 const SizedBox(width: 16),
                 Expanded(
                   child: ElevatedButton(
-                    onPressed: () {},
+                    onPressed: () {
+                      setState(() {
+                        // 기본 이미지 생성 로직 추가
+                        _showPreviewImage = true;
+                        _previewImage = null;
+                      });
+                    },
                     style: ElevatedButton.styleFrom(
                       elevation: 0,
                       padding: const EdgeInsets.symmetric(vertical: 12.0),

--- a/lib/features/notices/models/notice_model.dart
+++ b/lib/features/notices/models/notice_model.dart
@@ -1,11 +1,11 @@
 class Notice {
-  final String name;
+  final String title;
   final String date;
   final String description;
   final String imageUrl;
 
   Notice({
-    required this.name,
+    required this.title,
     required this.date,
     required this.description,
     required this.imageUrl,

--- a/lib/features/notices/screens/notice_insert_screen.dart
+++ b/lib/features/notices/screens/notice_insert_screen.dart
@@ -97,7 +97,7 @@ class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
         backgroundColor: MAIN_YELLOW,
         centerTitle: true,
         title: const Text(
-          '알림장',
+          '공지사항',
           style: TextStyle(
             fontSize: 20.0,
             fontWeight: FontWeight.w600,
@@ -115,31 +115,21 @@ class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
-              children: [
-                // Expanded(
-                //   child: DropdownButtonFormField<String>(
-                //     decoration: CustomInputDecoration.basic(
-                //       hintText: '담당자',
-                //     ),
-                //     items: const [
-                //       DropdownMenuItem(value: 'option1', child: Text('원장')),
-                //     ],
-                //     onChanged: (value) {},
-                //   ),
-                // ),
-                // const SizedBox(width: 16),
-                Expanded(
-                  child: TextFormField(
-                    controller: _dateController,
-                    readOnly: true,
-                    decoration: CustomInputDecoration.basic(
-                      hintText: '날짜',
-                    ),
-                    onTap: () => _openCustomDatePicker(context),
-                  ),
-                ),
-              ],
+
+            TextFormField(
+              controller: _dateController,
+              readOnly: true,
+              decoration: CustomInputDecoration.basic(
+                hintText: '날짜',
+              ),
+              onTap: () => _openCustomDatePicker(context),
+            ),
+
+            const SizedBox(height: 16),
+            TextFormField(
+              decoration: CustomInputDecoration.basic(
+                  hintText: '제목을 입력하세요.'
+              ),
             ),
             const SizedBox(height: 16),
             TextFormField(

--- a/lib/features/notices/screens/notice_insert_screen.dart
+++ b/lib/features/notices/screens/notice_insert_screen.dart
@@ -117,18 +117,18 @@ class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
           children: [
             Row(
               children: [
-                Expanded(
-                  child: DropdownButtonFormField<String>(
-                    decoration: CustomInputDecoration.basic(
-                      hintText: '담당자',
-                    ),
-                    items: const [
-                      DropdownMenuItem(value: 'option1', child: Text('원장')),
-                    ],
-                    onChanged: (value) {},
-                  ),
-                ),
-                const SizedBox(width: 16),
+                // Expanded(
+                //   child: DropdownButtonFormField<String>(
+                //     decoration: CustomInputDecoration.basic(
+                //       hintText: '담당자',
+                //     ),
+                //     items: const [
+                //       DropdownMenuItem(value: 'option1', child: Text('원장')),
+                //     ],
+                //     onChanged: (value) {},
+                //   ),
+                // ),
+                // const SizedBox(width: 16),
                 Expanded(
                   child: TextFormField(
                     controller: _dateController,
@@ -210,22 +210,6 @@ class _NoticeInsertScreenState extends State<NoticeInsertScreen> {
                       ),
                       child: const Text('사진추가'),
                     ),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () {},
-                    style: ElevatedButton.styleFrom(
-                      elevation: 0,
-                      padding: const EdgeInsets.symmetric(vertical: 12.0),
-                      backgroundColor: BLACK_COLOR,
-                      foregroundColor: MAIN_YELLOW,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10.0),
-                      ),
-                    ),
-                    child: const Text('AI 그림 생성'),
                   ),
                 ),
               ],

--- a/lib/features/notices/screens/parent_notice_detail_screen.dart
+++ b/lib/features/notices/screens/parent_notice_detail_screen.dart
@@ -47,7 +47,7 @@ class ParentNoticeDetailScreen extends StatelessWidget {
 
             SizedBox(height: 16),
             Text(
-              notice.name, // 전달받은 Note 데이터의 이름 표시
+              notice.title, // 전달받은 Note 데이터의 이름 표시
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
             ),
             SizedBox(height: 16),

--- a/lib/features/notices/screens/parent_notice_list_screen.dart
+++ b/lib/features/notices/screens/parent_notice_list_screen.dart
@@ -14,7 +14,7 @@ class _ParentNoticeListScreenState extends State<ParentNoticeListScreen> {
   List<Notice> items = List.generate(
     13,
         (index) => Notice(
-      name: '원장 $index', // 이름
+      title: '제목입니다. $index', // 이름
       date: '2025.01.0${index + 1}', // 날짜
       description:
       '오늘 우리 채아는 오전 간식을 아주 잘 먹고 나서 활기차게 놀이를 즐기며 시간을 보냈어요. 블록을 쌓고 무너뜨리며 상상력을 발휘했고, 동생과 함께 장난감 기차를 가지고 놀면서 사이좋게 웃음소리도 가득했답니다.',
@@ -83,7 +83,7 @@ class _ParentNoticeListScreenState extends State<ParentNoticeListScreen> {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
-                                items[index].name,
+                                items[index].title,
                                 style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
                               ),
                               Text(

--- a/lib/features/notices/screens/teacher_notice_detail_screen.dart
+++ b/lib/features/notices/screens/teacher_notice_detail_screen.dart
@@ -107,7 +107,7 @@ class TeacherNoticeDetailScreen extends StatelessWidget {
 
             SizedBox(height: 16),
             Text(
-              notice.name, // 전달받은 Notice 데이터의 이름 표시
+              notice.title, // 전달받은 Notice 데이터의 이름 표시
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
             ),
             SizedBox(height: 16),

--- a/lib/features/notices/screens/teacher_notice_list_screen.dart
+++ b/lib/features/notices/screens/teacher_notice_list_screen.dart
@@ -15,7 +15,7 @@ class _TeacherNoticeListScreenState extends State<TeacherNoticeListScreen> {
   List<Notice> items = List.generate(
     13,
         (index) => Notice(
-      name: '원장 $index', // 이름
+      title: '제목입니다. $index', // 이름
       date: '2025.01.0${index + 1}', // 날짜
       description:
       '오늘 우리 채아는 오전 간식을 아주 잘 먹고 나서 활기차게 놀이를 즐기며 시간을 보냈어요. 블록을 쌓고 무너뜨리며 상상력을 발휘했고, 동생과 함께 장난감 기차를 가지고 놀면서 사이좋게 웃음소리도 가득했답니다.',
@@ -126,7 +126,7 @@ class _TeacherNoticeListScreenState extends State<TeacherNoticeListScreen> {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  items[index].name,
+                                  items[index].title,
                                   style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
                                 ),
                                 Text(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,8 +11,8 @@ void main() {
         fontFamily: 'pretendard', // 기본 폰트 설정
         scaffoldBackgroundColor: Colors.white,
       ),
-      // home: TabScreen(key: TabScreen.tabScreenKey),
-      home: SignInScreen(),
+      home: TabScreen(key: TabScreen.tabScreenKey),
+      // home: SignInScreen(),
     ),
   );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'features/home/screens/parent_home_screen.dart';
 void main() {
   runApp(
     MaterialApp(
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
         fontFamily: 'pretendard', // 기본 폰트 설정
         scaffoldBackgroundColor: Colors.white,


### PR DESCRIPTION
## 💥 연관된 이슈
#61

## 🔨 작업 내용
- 교사 알림장 등록 스크린 드롭다운 메뉴 '반이름' -> '아이이름' 으로 변경
- 교사 알림장 등록 스크린 AI 그림 생성 버튼 탭 시 미리보기 이미지 생성 기능 구현
- 교사 공지사항 등록 부분 '반 이름', AI 그림생성 버튼 삭제                                             
- (공통) 공지사항 리스트뷰의 반 이름 텍스트 삭제
- 디버그 리본 삭제

## 👀작업 결과 이미지

![Screen_Recording_20250125_182713_1](https://github.com/user-attachments/assets/d0a6f0d2-3ee4-4e36-ace2-077c7065e61d)
![Screenshot_20250125_182817](https://github.com/user-attachments/assets/8377d41d-6a4f-461b-9220-801ef70b122d)
![Screenshot_20250125_182829](https://github.com/user-attachments/assets/d2b5ae7f-7943-491e-b57b-ffc7973759a0)
