### PR TITLE
FEAT(#63): 회원가입 API 연동 완료

### DIFF
--- a/lib/features/auth/models/signup_request.dart
+++ b/lib/features/auth/models/signup_request.dart
@@ -1,0 +1,23 @@
+class SignupRequest {
+  final String email;
+  final String password;
+  final String name;
+  final String role;
+  final int centerId;
+
+  SignupRequest({
+    required this.email,
+    required this.password,
+    required this.name,
+    required this.role,
+    required this.centerId,
+  });
+
+  Map<String, dynamic> toJson() => {
+    "email": email,
+    "password": password,
+    "name": name,
+    "role": role,
+    "centerId": centerId,
+  };
+}

--- a/lib/features/auth/models/signup_response.dart
+++ b/lib/features/auth/models/signup_response.dart
@@ -1,0 +1,26 @@
+class SignupResponse {
+  final int id;
+  final String email;
+  final String name;
+  final String role;
+  final int centerId;
+
+  SignupResponse({
+    required this.id,
+    required this.email,
+    required this.name,
+    required this.role,
+    required this.centerId,
+  });
+
+  // JSON 파싱 함수
+  factory SignupResponse.fromJson(Map<String, dynamic> json) {
+    return SignupResponse(
+      id: json['id'],
+      email: json['email'],
+      name: json['name'],
+      role: json['role'],
+      centerId: json['centerId'],
+    );
+  }
+}

--- a/lib/features/auth/providers/auth_provider.dart
+++ b/lib/features/auth/providers/auth_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
+import '../models/signup_request.dart';
+import '../services/auth_service.dart';
+
+final dioProvider = Provider<Dio>((ref) {
+  final dio = Dio();
+  dio.options.headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  };
+  return dio;
+});
+
+final authServiceProvider = Provider<AuthService>((ref) {
+  final dio = ref.read(dioProvider);
+  return AuthService(dio);
+});
+
+final registerProvider = FutureProvider.family.autoDispose<void, SignupRequest>((ref, request) async {
+  final authService = ref.read(authServiceProvider);
+  await authService.signup(request);
+});

--- a/lib/features/auth/screens/signin_screen.dart
+++ b/lib/features/auth/screens/signin_screen.dart
@@ -90,10 +90,7 @@ class SignInScreen extends StatelessWidget {
                 // 회원가입 링크
                 TextButton(
                   onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => const SignUpScreen()),
-                    );
+                    Navigator.pushNamed(context, '/signup'); // 회원가입 화면으로 이동
                   },
                   child: const Text(
                     '회원가입',

--- a/lib/features/auth/screens/signup_screen.dart
+++ b/lib/features/auth/screens/signup_screen.dart
@@ -1,14 +1,150 @@
+import 'dart:developer';
+
 import 'package:aimory_app/core/const/colors.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/widgets/custom_button.dart';
 import '../../../core/widgets/custom_input_decoration.dart';
+import '../models/signup_request.dart';
+import '../providers/auth_provider.dart';
 
-class SignUpScreen extends StatelessWidget {
+class SignUpScreen extends ConsumerWidget {
   const SignUpScreen({super.key});
 
+  Future<void> _showConfirmationDialog(
+      BuildContext context, WidgetRef ref, SignupRequest request) async {
+    // 키보드 포커스 해제
+    FocusScope.of(context).unfocus();
+    // 첫 번째 모달: 회원가입 완료 확인
+    final bool? shouldProceed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder( // 모서리 둥글게 설정
+            borderRadius: BorderRadius.circular(8),
+          ),
+          backgroundColor: Colors.white, // 배경색 흰색
+          title: const Text(
+            '회원가입 확인',
+            style: TextStyle(color: MAIN_DARK_GREY),
+          ),
+          content: const Text(
+            '회원가입을 완료하시겠습니까?',
+            style: TextStyle(color: MAIN_DARK_GREY),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context, false); // 취소 선택
+              },
+              child: const Text(
+                '취소',
+                style: TextStyle(color: MAIN_DARK_GREY),
+              ),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context, true); // 완료 선택
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: DARK_GREY_COLOR, // 완료 버튼 배경 검정
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8), // 버튼 모서리 둥글게
+                ),
+              ),
+              child: const Text('완료', style: TextStyle(color: Colors.white)), // 글씨 흰색
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldProceed == true) {
+      // 회원가입 처리 중 로딩 모달 띄우기
+      _showLoadingDialog(context);
+
+      try {
+        // API 호출
+        final authService = ref.read(authServiceProvider);
+        final response = await authService.signup(request);
+
+        // 로딩 모달 닫기
+        Navigator.pop(context);
+
+        // 성공 모달 띄우기
+        await showDialog<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              backgroundColor: Colors.white,
+              title: const Text(
+                '회원가입 성공',
+                style: TextStyle(color: DARK_GREY_COLOR),
+              ),
+              content: Text(
+                '${response.name}님, 회원가입이 완료되었습니다.',
+                style: const TextStyle(color: DARK_GREY_COLOR),
+              ),
+              actions: [
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.pop(context); // 성공 모달 닫기
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: DARK_GREY_COLOR,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: const Text('확인', style: TextStyle(color: Colors.white)),
+                ),
+              ],
+            );
+          },
+        );
+
+        // 로그인 화면으로 이동
+        Navigator.pushReplacementNamed(context, '/signin');
+      } catch (e) {
+        // 에러 발생 시 처리
+        Navigator.pop(context); // 로딩 모달 닫기
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('회원가입 실패: $e')),
+        );
+        log('회원가입 실패: $e', name: 'SignUp');
+      }
+    }
+  }
+
+  void _showLoadingDialog(BuildContext context) {
+    // 로딩 모달
+    showDialog(
+      context: context,
+      barrierDismissible: false, // 로딩 중에는 닫을 수 없도록 설정
+      builder: (BuildContext context) {
+        return const Center(
+          child: CircularProgressIndicator(),
+        );
+      },
+    );
+  }
+
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    // TextEditingController 초기화
+    final nameController = TextEditingController();
+    final emailController = TextEditingController();
+    final passwordController = TextEditingController();
+    final confirmPasswordController = TextEditingController(); // 비밀번호 확인 필드
+    final roleController = ValueNotifier<String>('PARENT'); // 역할 선택 값 관리
+    final centerController = ValueNotifier<int>(1); // 초기값: 1
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
@@ -35,41 +171,57 @@ class SignUpScreen extends StatelessWidget {
               children: [
                 const Text('어린이집'),
                 const SizedBox(height: 8),
-                DropdownButtonFormField<String>(
+                DropdownButtonFormField<int>(
+                  value: centerController.value, // centerController의 초기값
                   items: [
                     DropdownMenuItem(
-                      value: 'centerName',
+                      value: 1, // 값이 초기값과 일치해야 함
                       child: Text('햇님어린이집'),
                     ),
                   ],
-                  onChanged: (value) {},
+                  onChanged: (value) {
+                    centerController.value = value ?? 1;
+                  },
                   decoration: CustomInputDecoration.basic(
-                    hintText: '햇님어린이집',
+                    hintText: '어린이집을 선택하세요.', // 힌트 문구
                   ),
                 ),
                 const SizedBox(height: 16),
                 const Text('역할'),
                 const SizedBox(height: 8),
                 DropdownButtonFormField<String>(
+                  value: roleController.value, // 기본값 설정
                   items: [
                     DropdownMenuItem(
-                      value: 'user',
-                      child: Text('사용자'),
+                      value: 'TEACHER',
+                      child: Text('교사'),
                     ),
                     DropdownMenuItem(
-                      value: 'admin',
-                      child: Text('관리자'),
+                      value: 'PARENT',
+                      child: Text('부모님'),
                     ),
                   ],
-                  onChanged: (value) {},
+                  onChanged: (value) {
+                    roleController.value = value ?? 'PARENT'; // 선택값 업데이트
+                  },
                   decoration: CustomInputDecoration.basic(
                     hintText: '역할을 선택하세요.',
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text('이메일'),
+                const SizedBox(height: 8),
+                TextFormField(
+                  controller: emailController,
+                  decoration: CustomInputDecoration.basic(
+                    hintText: '이메일을 입력하세요.',
                   ),
                 ),
                 const SizedBox(height: 16),
                 const Text('이름'),
                 const SizedBox(height: 8),
                 TextFormField(
+                  controller: nameController,
                   decoration: CustomInputDecoration.basic(
                     hintText: '이름을 입력하세요.',
                   ),
@@ -78,6 +230,7 @@ class SignUpScreen extends StatelessWidget {
                 const Text('비밀번호'),
                 const SizedBox(height: 8),
                 TextFormField(
+                  controller: passwordController,
                   obscureText: true,
                   decoration: CustomInputDecoration.basic(
                     hintText: '비밀번호',
@@ -87,24 +240,36 @@ class SignUpScreen extends StatelessWidget {
                 const Text('비밀번호 확인'),
                 const SizedBox(height: 8),
                 TextFormField(
+                  controller: confirmPasswordController,
                   obscureText: true,
                   decoration: CustomInputDecoration.basic(
                     hintText: '비밀번호 확인',
                   ),
                 ),
-                const SizedBox(height: 16),
-                const Text('이메일'),
-                const SizedBox(height: 8),
-                TextFormField(
-                  decoration: CustomInputDecoration.basic(
-                    hintText: '이메일을 입력하세요.',
-                  ),
-                ),
+
                 const SizedBox(height: 24),
                 CustomButton(
                   text: '회원가입',
                   onPressed: () {
-                    print('회원가입 버튼 클릭');
+                    // 입력값 검증
+                    if (passwordController.text != confirmPasswordController.text) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text("비밀번호가 일치하지 않습니다.")),
+                      );
+                      return;
+                    }
+
+                    // SignupRequest 생성
+                    final request = SignupRequest(
+                      email: emailController.text,
+                      password: passwordController.text,
+                      name: nameController.text,
+                      role: roleController.value,
+                      centerId: centerController.value,
+                    );
+
+                    // 확인 모달 띄우기
+                    _showConfirmationDialog(context, ref, request);
                   },
                 ),
               ],

--- a/lib/features/auth/services/auth_service.dart
+++ b/lib/features/auth/services/auth_service.dart
@@ -1,0 +1,15 @@
+import 'package:retrofit/retrofit.dart';
+import 'package:dio/dio.dart';
+import '../models/signup_request.dart';
+import '../models/signup_response.dart';
+
+part 'auth_service.g.dart'; // Retrofit 자동 생성 파일
+
+@RestApi(baseUrl: "http://aimory.ap-northeast-2.elasticbeanstalk.com")
+abstract class AuthService {
+  factory AuthService(Dio dio, {String baseUrl}) = _AuthService;
+
+  /// 회원가입 API
+  @POST("/signup")
+  Future<SignupResponse> signup(@Body() SignupRequest request);
+}

--- a/lib/features/auth/services/auth_service.g.dart
+++ b/lib/features/auth/services/auth_service.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auth_service.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+
+class _AuthService implements AuthService {
+  _AuthService(this._dio, {this.baseUrl, this.errorLogger}) {
+    baseUrl ??= 'http://aimory.ap-northeast-2.elasticbeanstalk.com';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<SignupResponse> signup(SignupRequest request) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(request.toJson());
+    final _options = _setStreamType<SignupResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/signup',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late SignupResponse _value;
+    try {
+      _value = SignupResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,37 @@
 import 'package:aimory_app/core/screens/tab_screen.dart';
 import 'package:aimory_app/features/auth/screens/signin_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart'; // Riverpod 추가
 
+import 'features/auth/screens/signup_screen.dart';
 import 'features/home/screens/parent_home_screen.dart';
 
 void main() {
   runApp(
-    MaterialApp(
+    const ProviderScope( // ProviderScope로 루트를 감쌈
+      child: AimoryApp(),
+    ),
+  );
+}
+
+class AimoryApp extends StatelessWidget {
+  const AimoryApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         fontFamily: 'pretendard', // 기본 폰트 설정
         scaffoldBackgroundColor: Colors.white,
       ),
-      home: TabScreen(key: TabScreen.tabScreenKey),
-      // home: SignInScreen(),
-    ),
-  );
+      // home: TabScreen(key: TabScreen.tabScreenKey),
+      // home: SignInScreen(), // 시작 화면 설정
+      initialRoute: '/signin', // 앱 시작 경로
+      routes: {
+        '/signin': (context) => const SignInScreen(), // 로그인 화면
+        '/signup': (context) => const SignUpScreen(), // 회원가입 화면
+      },
+    );
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -347,6 +347,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.24"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -510,7 +518,7 @@ packages:
     source: hosted
     version: "0.7.1"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
@@ -518,7 +526,7 @@ packages:
     source: hosted
     version: "4.9.0"
   json_serializable:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: json_serializable
       sha256: "8f52361c07497a7f2c16c13aac159f9be6fb12b1d67719eac98a21d9a205d571"
@@ -693,6 +701,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.1"
+  protobuf:
+    dependency: transitive
+    description:
+      name: protobuf
+      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   provider:
     dependency: "direct main"
     description:
@@ -717,6 +733,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  retrofit:
+    dependency: "direct main"
+    description:
+      name: retrofit
+      sha256: c6cc9ad3374e6d07008343140a67afffaaa34cdf6bf08d4847d91417a99dcf45
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.2"
+  retrofit_generator:
+    dependency: "direct dev"
+    description:
+      name: retrofit_generator
+      sha256: da17daf8cfdf695a402c894e4eebf91d2e815a47368820dd7a0b41a027739a9c
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.7"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -826,6 +866,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,15 +36,17 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter_dotenv: ^5.2.1
 
-
   http: ^1.2.2          # API 통신
   provider: ^6.1.0      # 상태 관리
   shared_preferences: ^2.0.15 # 로컬 저장소
   dio: ^5.7.0           # 고급 HTTP 통신
-  json_serializable: ^6.7.1 # JSON 처리
+#  json_serializable: ^6.7.1 # JSON 처리
   flutter_native_splash: ^2.4.4
   intl: ^0.20.1
   image_picker: ^0.8.7+3
+  retrofit: ^4.4.2
+  json_annotation: ^4.9.0
+  flutter_riverpod: ^2.0.0
 
 dev_dependencies:
   flutter_test:
@@ -57,9 +59,13 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
 
-  build_runner: ^2.3.3  # 코드 생성 도구
+  build_runner: ^2.4.13  # 코드 생성 도구
 
   flutter_launcher_icons: ^0.13.1
+
+  retrofit_generator: ^9.1.5
+
+  json_serializable: ^6.9.0
 
 flutter_icons:
   android: true # 안드로이드 아이콘 변경


### PR DESCRIPTION
## 💥 연관된 이슈
#63

## 🔨 작업 내용
- Signup 모델 추가
- authProvider 추가
- AuthService 클래스 추가하여 Retrofit 인터페이스 구현
- main.dart route 경로 추가
- 회원가입 화면 수정(ConsumerWidget으로 변경하여 Riverpod Provider)
- 회원가입 AlertDialog 추가로 회원가입 확인 추가
- 디버그 리본 삭제

## 👀작업 결과 이미지
![Screen_Recording_20250127_211225_1](https://github.com/user-attachments/assets/03bb0210-50f4-47ca-8f9f-7504c192bc5b)
