### PR TITLE
FEAT(#73): 공지사항 단일 조회 API 연동

### DIFF
--- a/lib/features/notices/models/notice_model.g.dart
+++ b/lib/features/notices/models/notice_model.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notice_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+NoticeModel _$NoticeModelFromJson(Map<String, dynamic> json) => NoticeModel(
+      id: (json['id'] as num?)?.toInt(),
+      centerId: (json['centerId'] as num).toInt(),
+      images:
+          (json['images'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      title: json['title'] as String,
+      content: json['content'] as String,
+      date: json['date'] as String?,
+      createdAt: json['createdAt'] as String?,
+      updatedAt: json['updatedAt'] as String?,
+    );
+
+Map<String, dynamic> _$NoticeModelToJson(NoticeModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'centerId': instance.centerId,
+      'images': instance.images,
+      'title': instance.title,
+      'content': instance.content,
+      'date': instance.date,
+      'createdAt': instance.createdAt,
+      'updatedAt': instance.updatedAt,
+    };

--- a/lib/features/notices/provider/notice_provider.dart
+++ b/lib/features/notices/provider/notice_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
+import '../models/notice_model.dart';
+import '../services/notice_service.dart';
+import '../../../core/util/secure_storage.dart';
+
+final dioProvider = Provider<Dio>((ref) {
+  final dio = Dio();
+  return dio;
+});
+
+final noticeServiceProvider = Provider<NoticeService>((ref) {
+  final dio = ref.read(dioProvider);
+  return NoticeService(dio);
+});
+
+/// ✅ 공지사항 리스트를 관리하는 FutureProvider
+final noticeListProvider = FutureProvider<List<NoticeModel>>((ref) async {
+  final service = ref.read(noticeServiceProvider);
+  final token = await SecureStorage.readToken();
+  if (token == null) {
+    throw Exception("토큰이 존재하지 않습니다.");
+  }
+  return service.getNotices("Bearer $token");
+});
+
+/// ✅ 공지사항 단일 조회 추가
+final noticeDetailProvider = FutureProvider.family<NoticeModel, int>((ref, noticeId) async {
+  final service = ref.read(noticeServiceProvider);
+  final token = await SecureStorage.readToken();
+  if (token == null) {
+    throw Exception("토큰이 존재하지 않습니다.");
+  }
+  return service.getNoticeById("Bearer $token", noticeId);
+});
+

--- a/lib/features/notices/screens/parent_notice_detail_screen.dart
+++ b/lib/features/notices/screens/parent_notice_detail_screen.dart
@@ -1,27 +1,25 @@
-import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/const/colors.dart';
 import '../models/notice_model.dart';
+import '../provider/notice_provider.dart';
 
-class ParentNoticeDetailScreen extends StatelessWidget {
+class ParentNoticeDetailScreen extends ConsumerWidget {
+  final int noticeId; // 공지사항 ID를 기반으로 데이터 가져오기
 
-  final NoticeModel notice; // Notice 데이터 전달받음
-  // 생성자에서 Note 데이터 초기화
-  const ParentNoticeDetailScreen({Key? key, required this.notice}) : super(key: key);
-
+  const ParentNoticeDetailScreen({Key? key, required this.noticeId}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final noticeAsync = ref.watch(noticeDetailProvider(noticeId));
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: MAIN_YELLOW,
         centerTitle: true,
         title: const Text(
-          '알림장',
-          style: TextStyle(
-            fontSize: 20.0,
-            fontWeight: FontWeight.w600,
-          ),
+          '공지사항',
+          style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w600),
         ),
         leading: IconButton(
           icon: const Icon(Icons.keyboard_backspace),
@@ -30,44 +28,39 @@ class ParentNoticeDetailScreen extends StatelessWidget {
           },
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  notice.date ?? "", // 전달받은 Notice 데이터의 날짜 표시
-                  style: TextStyle(fontSize: 16, color: LIGHT_GREY_COLOR),
+      body: noticeAsync.when(
+        data: (notice) => Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(notice.date ?? "날짜 없음", style: const TextStyle(fontSize: 16, color: LIGHT_GREY_COLOR)),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text(notice.title, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w700)),
+              const SizedBox(height: 16),
+              notice.images != null && notice.images!.isNotEmpty
+                  ? ClipRRect(
+                borderRadius: BorderRadius.circular(8.0),
+                child: Image.network(
+                  notice.images!.first,
+                  fit: BoxFit.cover,
+                  height: 200,
+                  width: double.infinity,
                 ),
-                SizedBox(width: 10.0,),
-              ],
-            ),
-
-            SizedBox(height: 16),
-            Text(
-              notice.title, // 전달받은 Note 데이터의 이름 표시
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
-            ),
-            SizedBox(height: 16),
-            ClipRRect(
-              borderRadius: BorderRadius.circular(8.0),
-              child: Image.network(
-                notice.images?.isNotEmpty == true ? notice.images!.first : "https://via.placeholder.com/200",
-                fit: BoxFit.cover,
-                height: 200,
-                width: double.infinity,
               )
-            ),
-            SizedBox(height: 16),
-            Text(
-              notice.content, // 전달받은 Note 데이터의 설명 표시
-              style: TextStyle(fontSize: 16),
-            ),
-          ],
+                  : const Icon(Icons.image_not_supported, size: 80, color: Colors.grey),
+              const SizedBox(height: 16),
+              Text(notice.content, style: const TextStyle(fontSize: 16)),
+            ],
+          ),
         ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text("공지사항을 불러오지 못했습니다: $error")),
       ),
     );
   }

--- a/lib/features/notices/screens/parent_notice_list_screen.dart
+++ b/lib/features/notices/screens/parent_notice_list_screen.dart
@@ -43,7 +43,9 @@ class ParentNoticeListScreen extends ConsumerWidget {
                       onTap: () {
                         Navigator.push(
                           context,
-                          MaterialPageRoute(builder: (context) => ParentNoticeDetailScreen(notice: notice)),
+                          MaterialPageRoute(
+                            builder: (context) => ParentNoticeDetailScreen(noticeId: notice.id!), // ✅ ID만 전달
+                          ),
                         );
                       },
                       child: Container(

--- a/lib/features/notices/screens/teacher_notice_detail_screen.dart
+++ b/lib/features/notices/screens/teacher_notice_detail_screen.dart
@@ -1,132 +1,66 @@
-import 'package:aimory_app/core/const/colors.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/const/colors.dart';
 import '../models/notice_model.dart';
-import 'notice_insert_screen.dart';
+import '../provider/notice_provider.dart';
 
-class TeacherNoticeDetailScreen extends StatelessWidget {
+class TeacherNoticeDetailScreen extends ConsumerWidget {
+  final int noticeId; // 공지사항 ID를 받아서 API에서 불러옴
 
-  final Notice notice; // Notice 데이터 전달받음
-  // 생성자에서 Notice 데이터 초기화
-  const TeacherNoticeDetailScreen({Key? key, required this.notice}) : super(key: key);
-
+  const TeacherNoticeDetailScreen({Key? key, required this.noticeId}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final noticeAsync = ref.watch(noticeDetailProvider(noticeId));
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: MAIN_YELLOW,
         centerTitle: true,
         title: const Text(
           '공지사항',
-          style: TextStyle(
-            fontSize: 20.0,
-            fontWeight: FontWeight.w600,
-          ),
+          style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w600),
         ),
         leading: IconButton(
           icon: const Icon(Icons.keyboard_backspace),
           onPressed: () {
-            Navigator.pop(context, false); // 뒤로가기 시 삭제되지 않음을 반환
+            Navigator.pop(context, false);
           },
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  notice.date, // 전달받은 Notice 데이터의 날짜 표시
-                  style: TextStyle(fontSize: 16, color: LIGHT_GREY_COLOR),
-                ),
-                Row(
-                  children: [
-                    Align(
-                      alignment: Alignment.centerLeft,
-                      child: TextButton.icon(
-                        onPressed: () {
-                          // 공지사항 작성하는 스크린 넘어가도록 작업예정
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(builder: (context) => const NoticeInsertScreen()),
-                          );
-                        }, // 알림장 수정 기능
-                        label: const Text(
-                          "수정하기",
-                          style: TextStyle(
-                              color: DARK_GREY_COLOR,
-                              fontSize: 14
-                          ),
-                        ),
-                        style: TextButton.styleFrom(
-                          backgroundColor: Colors.white,
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(20),
-                              side: BorderSide(
-                                color: MID_GREY_COLOR, // 테두리 색상
-                                width: 1, // 테두리 두께
-                              )
-                          ),
-                        ),
-                      ),
-                    ),
-                    SizedBox(width: 10.0,),
-                    Align(
-                      alignment: Alignment.centerLeft,
-                      child: TextButton.icon(
-                        onPressed: () {
-                          // 삭제 버튼 클릭 시 삭제 후 리스트 화면으로 이동
-                          Navigator.pop(context, true); // 삭제 성공 상태 반환
-                        },
-                        label: const Text(
-                          "삭제하기",
-                          style: TextStyle(
-                              color: DARK_GREY_COLOR,
-                              fontSize: 14
-                          ),
-                        ),
-                        style: TextButton.styleFrom(
-                          backgroundColor: Colors.white,
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(20),
-                              side: BorderSide(
-                                color: MID_GREY_COLOR, // 테두리 색상
-                                width: 1, // 테두리 두께
-                              )
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-
-            SizedBox(height: 16),
-            Text(
-              notice.title, // 전달받은 Notice 데이터의 이름 표시
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
-            ),
-            SizedBox(height: 16),
-            ClipRRect(
-              borderRadius: BorderRadius.circular(8.0),
-              child: Image.asset(
-                notice.imageUrl, // 전달받은 Notice 데이터의 이미지 URL
-                fit: BoxFit.cover,
-                height: 200,
-                width: double.infinity,
+      body: noticeAsync.when(
+        data: (notice) => Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(notice.date ?? "날짜 없음", style: const TextStyle(fontSize: 16, color: LIGHT_GREY_COLOR)),
+                ],
               ),
-            ),
-            SizedBox(height: 16),
-            Text(
-              notice.description, // 전달받은 Notice 데이터의 설명 표시
-              style: TextStyle(fontSize: 16),
-            ),
-          ],
+              const SizedBox(height: 16),
+              Text(notice.title, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w700)),
+              const SizedBox(height: 16),
+              notice.images != null && notice.images!.isNotEmpty
+                  ? ClipRRect(
+                borderRadius: BorderRadius.circular(8.0),
+                child: Image.network(
+                  notice.images!.first,
+                  fit: BoxFit.cover,
+                  height: 200,
+                  width: double.infinity,
+                ),
+              )
+                  : const Icon(Icons.image_not_supported, size: 80, color: Colors.grey),
+              const SizedBox(height: 16),
+              Text(notice.content, style: const TextStyle(fontSize: 16)),
+            ],
+          ),
         ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text("공지사항을 불러오지 못했습니다: $error")),
       ),
     );
   }

--- a/lib/features/notices/screens/teacher_notice_list_screen.dart
+++ b/lib/features/notices/screens/teacher_notice_list_screen.dart
@@ -61,7 +61,9 @@ class TeacherNoticeListScreen extends ConsumerWidget {
                       onTap: () {
                         Navigator.push(
                           context,
-                          MaterialPageRoute(builder: (context) => TeacherNoticeDetailScreen(notice: notice)),
+                          MaterialPageRoute(
+                            builder: (context) => TeacherNoticeDetailScreen(noticeId: notice.id!), // ✅ ID만 전달
+                          ),
                         );
                       },
                       child: Container(

--- a/lib/features/notices/services/notice_service.dart
+++ b/lib/features/notices/services/notice_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert'; // ✅ jsonEncode 사용을 위해 추가
+
+import 'package:retrofit/retrofit.dart';
+import 'package:dio/dio.dart';
+import '../models/notice_model.dart';
+
+part 'notice_service.g.dart';
+
+@RestApi(baseUrl: "http://aimory.ap-northeast-2.elasticbeanstalk.com")
+abstract class NoticeService {
+  factory NoticeService(Dio dio, {String baseUrl}) = _NoticeService;
+
+  /// ✅ 공지사항 생성 API
+  @POST("/notices")
+  @MultiPart()
+  Future<NoticeModel> createNotice(
+      @Header("Authorization") String token,
+      @Part(name: "data") String noticeJson, // JSON 문자열로 변경
+      @Part(name: "images") List<MultipartFile>? images, //  이미지 업로드 추가
+      );
+
+  /// ✅ 공지사항 전체 조회 API
+  @GET("/notices")
+  Future<List<NoticeModel>> getNotices(@Header("Authorization") String token);
+
+  /// ✅ 공지사항 단일 조회 API 추가
+  @GET("/notices/{notice_id}")
+  Future<NoticeModel> getNoticeById(
+      @Header("Authorization") String token,
+      @Path("notice_id") int noticeId,
+      );
+
+
+}

--- a/lib/features/notices/services/notice_service.g.dart
+++ b/lib/features/notices/services/notice_service.g.dart
@@ -1,0 +1,150 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notice_service.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+
+class _NoticeService implements NoticeService {
+  _NoticeService(this._dio, {this.baseUrl, this.errorLogger}) {
+    baseUrl ??= 'http://aimory.ap-northeast-2.elasticbeanstalk.com';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<NoticeModel> createNotice(
+    String token,
+    String noticeJson,
+    List<MultipartFile>? images,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{r'Authorization': token};
+    _headers.removeWhere((k, v) => v == null);
+    final _data = FormData();
+    _data.fields.add(MapEntry('data', noticeJson));
+    if (images != null) {
+      _data.files.addAll(images.map((i) => MapEntry('images', i)));
+    }
+    final _options = _setStreamType<NoticeModel>(
+      Options(
+        method: 'POST',
+        headers: _headers,
+        extra: _extra,
+        contentType: 'multipart/form-data',
+      )
+          .compose(
+            _dio.options,
+            '/notices',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late NoticeModel _value;
+    try {
+      _value = NoticeModel.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<List<NoticeModel>> getNotices(String token) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'Authorization': token};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<NoticeModel>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/notices',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<NoticeModel> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) => NoticeModel.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<NoticeModel> getNoticeById(String token, int noticeId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'Authorization': token};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<NoticeModel>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/notices/${noticeId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late NoticeModel _value;
+    try {
+      _value = NoticeModel.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}


### PR DESCRIPTION
## 💥 연관된 이슈
#73

## 🔨 작업 내용
- Provider 공지사항 단일 조회 추가
- Service 공지사항 단일 조회 API 추가
- 공지사항 단일 조회 UI/로직 수정
- 공지사항 리스트 NoticeModel 객체 전달에서 noticeId만 전달하도록 변경
