### PR TITLE
FEAT(#88): 로그인 버튼 로그인 API 호출 연동

### DIFF
--- a/lib/core/screens/tab_screen.dart
+++ b/lib/core/screens/tab_screen.dart
@@ -11,9 +11,10 @@ import '../../features/notes/screens/teacher_note_list_screen.dart';
 import '../../features/photos/screens/parent_photo_list_screen.dart';
 import '../../features/photos/screens/teacher_album_screen.dart';
 import '../../features/auth/screens/teacher_info_screen.dart';
+import 'dart:developer' as dev;
 
 class TabScreen extends StatefulWidget {
-  static final GlobalKey<_TabScreenState> tabScreenKey = GlobalKey<_TabScreenState>(); // GlobalKey 추가
+  static final GlobalKey<_TabScreenState> tabScreenKey = GlobalKey<_TabScreenState>();
 
   const TabScreen({Key? key}) : super(key: key);
 
@@ -22,32 +23,22 @@ class TabScreen extends StatefulWidget {
 }
 
 class _TabScreenState extends State<TabScreen> with SingleTickerProviderStateMixin {
-  late TabController _tabController; // TabController
-  String? role;
+  late TabController _tabController;
 
   @override
   void initState() {
     super.initState();
     _tabController = TabController(length: 5, vsync: this);
-    _loadRole();
-  }
-
-  Future<void> _loadRole() async {
-    final storedRole = await SecureStorage.readUserRole();
-    setState(() {
-      role = storedRole;
-    });
   }
 
   void changeTab(int index) {
     if (index < 0 || index >= _tabController.length) return;
-    _tabController.animateTo(index); // 탭 이동
+    _tabController.animateTo(index);
   }
-
 
   @override
   void dispose() {
-    _tabController.dispose(); // TabController 해제
+    _tabController.dispose();
     super.dispose();
   }
 
@@ -63,8 +54,9 @@ class _TabScreenState extends State<TabScreen> with SingleTickerProviderStateMix
         }
 
         final userRole = snapshot.data ?? "UNKNOWN"; // 기본값 UNKNOWN 처리
+        debugPrint("현재 사용자 role: $userRole");
 
-        // ✅ role에 따른 TabView 설정
+
         final List<Widget> tabViews = userRole == "TEACHER"
             ? [
           TeacherHomeScreen(),
@@ -78,12 +70,12 @@ class _TabScreenState extends State<TabScreen> with SingleTickerProviderStateMix
           ParentHomeScreen(),
           ParentNoticeListScreen(),
           ParentNoteListScreen(),
-          ParentPhotoListScreen(childId: 123), // 원아 ID 직접 전달
+          ParentPhotoListScreen(childId: 123),
           ParentInfoScreen(),
         ]
             : [
           Scaffold(body: Center(child: Text("잘못된 접근입니다. 🚨"))),
-        ]; // ✅ role이 없거나 잘못된 경우 기본 화면
+        ];
 
         return Scaffold(
           appBar: _tabController.index == 0
@@ -98,7 +90,7 @@ class _TabScreenState extends State<TabScreen> with SingleTickerProviderStateMix
           ),
           body: TabBarView(
             controller: _tabController,
-            children: tabViews, // ✅ role에 맞는 TabView 적용
+            children: tabViews,
           ),
           bottomNavigationBar: BottomNavigationBar(
             currentIndex: _tabController.index,

--- a/lib/features/auth/screens/signin_screen.dart
+++ b/lib/features/auth/screens/signin_screen.dart
@@ -1,16 +1,51 @@
-import 'package:aimory_app/features/auth/screens/signup_screen.dart';
+import 'package:aimory_app/core/const/colors.dart';
+import 'package:aimory_app/core/util/secure_storage.dart';
+import 'package:aimory_app/features/auth/services/auth_service.dart';
 import 'package:flutter/material.dart';
-
-import '../../../core/const/colors.dart';
+import '../../../core/screens/tab_screen.dart';
 import '../../../core/widgets/custom_button.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class SignInScreen extends StatelessWidget {
+import '../providers/auth_provider.dart';
+
+class SignInScreen extends ConsumerStatefulWidget {
   const SignInScreen({Key? key}) : super(key: key);
+
+  @override
+  _SignInScreenState createState() => _SignInScreenState();
+}
+
+class _SignInScreenState extends ConsumerState<SignInScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  Future<void> _login(BuildContext context) async {
+    final authService = ref.read(authServiceProvider);
+    final email = _emailController.text;
+    final password = _passwordController.text;
+
+    bool success = await performLogin(authService, email, password);
+
+    if (success) {
+      // ✅ 로그인 성공 시 role 확인 후 TabScreen으로 이동
+      final role = await SecureStorage.readUserRole();
+      if (mounted) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (context) => TabScreen()), // ✅ role 제거
+        );
+      }
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("로그인 실패. 이메일 또는 비밀번호를 확인하세요.")),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: MAIN_YELLOW, // 배경색
+      backgroundColor: MAIN_YELLOW,
       body: SafeArea(
         child: SingleChildScrollView(
           child: Padding(
@@ -18,15 +53,14 @@ class SignInScreen extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                const SizedBox(height: 50), // 로고 위 여백
-                // 로고 이미지
+                const SizedBox(height: 150),
                 Image.asset(
-                  'assets/img/aimory_calendar_logo.png', // 로고 파일 경로
+                  'assets/img/aimory_calendar_logo.png',
                   height: 120,
                 ),
-                const SizedBox(height: 60), // 로고 아래 여백
-                // 이메일 입력 필드
+                const SizedBox(height: 60),
                 TextField(
+                  controller: _emailController,
                   decoration: InputDecoration(
                     hintText: '이메일 입력',
                     border: OutlineInputBorder(
@@ -37,9 +71,9 @@ class SignInScreen extends StatelessWidget {
                     fillColor: Colors.white,
                   ),
                 ),
-                const SizedBox(height: 15), // 필드 간 여백
-                // 비밀번호 입력 필드
+                const SizedBox(height: 15),
                 TextField(
+                  controller: _passwordController,
                   obscureText: true,
                   decoration: InputDecoration(
                     hintText: '비밀번호 입력',
@@ -52,45 +86,15 @@ class SignInScreen extends StatelessWidget {
                     fillColor: Colors.white,
                   ),
                 ),
-                const SizedBox(height: 10), // 필드 아래 여백
-                // 이메일 저장 및 비밀번호 찾기
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Row(
-                      children: [
-                        Checkbox(value: false, onChanged: (value) {}),
-                        const Text('이메일 저장'),
-                      ],
-                    ),
-                    Row(
-                      children: const [
-                        Text(
-                          '이메일 찾기',
-                        ),
-                        SizedBox(width: 8),
-                        Text('|'),
-                        SizedBox(width: 8),
-                        Text(
-                          '비밀번호 찾기',
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 20), // 버튼 위 여백
-                // 로그인 버튼
+                const SizedBox(height: 20),
                 CustomButton(
                   text: '로그인',
-                  onPressed: () {
-                    print('로그인 버튼 클릭');
-                  },
+                  onPressed: () => _login(context),
                 ),
-                const SizedBox(height: 30), // 하단 텍스트 여백
-                // 회원가입 링크
+                const SizedBox(height: 30),
                 TextButton(
                   onPressed: () {
-                    Navigator.pushNamed(context, '/signup'); // 회원가입 화면으로 이동
+                    Navigator.pushNamed(context, '/signup');
                   },
                   child: const Text(
                     '회원가입',

--- a/lib/features/auth/services/auth_service.dart
+++ b/lib/features/auth/services/auth_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:dio/dio.dart';
 import 'package:retrofit/http.dart';
@@ -31,17 +32,18 @@ Future<bool> performLogin(AuthService authService, String email, String password
     if (response.apiToken.isNotEmpty) {
 
       await SecureStorage.saveToken(response.apiToken); // Access Token 저장
+      await SecureStorage.saveUserRole(response.member.role);
       await SecureStorage.saveTeacherId(response.member.id); // teacherId 저장
-      print("로그인 성공! Access Token: ${response.apiToken}");
-      print("사용자 정보: ${response.member.name} (${response.member.role})");
+      debugPrint("로그인 성공! Access Token: ${response.apiToken}");
+      debugPrint("사용자 정보: ${response.member.name} (${response.member.role})");
 
       return true;
     } else {
-      print("로그인 실패: 응답에 토큰이 없습니다.");
+      debugPrint("로그인 실패: 응답에 토큰이 없습니다.");
       return false;
     }
   } catch (e) {
-    print("로그인 요청 중 오류 발생: $e");
+    debugPrint("로그인 요청 중 오류 발생: $e");
     return false;
   }
 }

--- a/lib/features/home/appbar/parent_home_app_bar.dart
+++ b/lib/features/home/appbar/parent_home_app_bar.dart
@@ -12,6 +12,7 @@ class ParentHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: MAIN_YELLOW,
       elevation: 0,
       toolbarHeight: 400, // 앱바의 높이 설정
+      automaticallyImplyLeading: false, // 기본값인 뒤로가기 버튼 제거
       title: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10.0,),
         child: Column(

--- a/lib/features/home/appbar/teacher_home_app_bar.dart
+++ b/lib/features/home/appbar/teacher_home_app_bar.dart
@@ -10,7 +10,8 @@ class TeacherHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       backgroundColor: MAIN_YELLOW,
       elevation: 0,
-      toolbarHeight: 250, // 앱바의 높이 설정
+      toolbarHeight: 280, // 앱바의 높이 설정
+      automaticallyImplyLeading: false, // 기본값인 뒤로가기 버튼 제거
       title: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10.0,),
         child: Column(
@@ -52,7 +53,7 @@ class TeacherHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
                 ),
               ],
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: 50),
             // 날짜, 이름, 반 정보
             Text(
               "05월26일 금요일",
@@ -128,5 +129,5 @@ class TeacherHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(240);
+  Size get preferredSize => const Size.fromHeight(260);
 }


### PR DESCRIPTION
## 💥 연관된 이슈
#88

## 🔨 작업 내용
- 로그인 버튼 누를 시 로그인 API 호출하도록 연동(SignInScreen)
- AuthService의 performLogin 메서드 saveUserRole 완료 된 후에 readUserRole 실행되도록 saveRole 추가
- appBar 뒤로가기 버튼 제거
