### PR TITLE
FEAT(#101): 공지사항 삭제 API 연동

### DIFF
--- a/lib/features/notices/services/notice_service.dart
+++ b/lib/features/notices/services/notice_service.dart
@@ -1,11 +1,14 @@
 import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:dio/dio.dart';
+import '../../../core/util/secure_storage.dart';
 import '../models/notice_model.dart';
+import '../provider/notice_provider.dart';
 
 part 'notice_service.g.dart';
 
-@RestApi()
+@RestApi(baseUrl: "http://aimory.ap-northeast-2.elasticbeanstalk.com")
 abstract class NoticeService {
   factory NoticeService(Dio dio, {String baseUrl}) = _NoticeService;
 
@@ -14,13 +17,13 @@ abstract class NoticeService {
   @MultiPart()
   Future<NoticeModel> createNotice(
       @Header("Authorization") String token,
-      @Part(name: "data") String noticeJson, // JSON 문자열
-      @Part(name: "images") List<MultipartFile>? images, // 이미지 업로드
+      @Part(name: "data") String noticeJson,
+      @Part(name: "images") List<MultipartFile>? images,
       );
 
   /// ✅ 공지사항 전체 조회 API
   @GET("/notices")
-  Future<List<NoticeModel>> getNotices(@Header("Authorization") String token);
+  Future<dynamic> getNotices(@Header("Authorization") String token);
 
   /// ✅ 공지사항 단일 조회 API
   @GET("/notices/{notice_id}")
@@ -29,10 +32,31 @@ abstract class NoticeService {
       @Path("notice_id") int noticeId,
       );
 
-  /// ✅ 공지사항 삭제 API (여러 개 삭제 가능)
+  /// ✅ 공지사항 삭제 API
   @DELETE("/notices")
   Future<void> deleteNotices(
       @Header("Authorization") String token,
-      @Body() Map<String, dynamic> requestBody, // 백엔드가 Body를 받는 경우 유지
+      @Body() Map<String, dynamic> requestBody,
       );
 }
+
+/// ✅ 공지사항 리스트를 관리하는 FutureProvider
+final noticeListProvider = FutureProvider<List<NoticeModel>>((ref) async {
+  final service = ref.read(noticeServiceProvider);
+  final token = await SecureStorage.readToken();
+  if (token == null) {
+    throw Exception("토큰이 존재하지 않습니다.");
+  }
+
+  final rawResponse = await service.getNotices("Bearer $token");
+
+  // 🔹 응답이 `Map<String, dynamic>`이면 `{ "notices": [...] }` 형태일 가능성 높음
+  if (rawResponse is Map<String, dynamic> && rawResponse.containsKey("notices")) {
+    final noticesList = rawResponse["notices"];
+    if (noticesList is List) {
+      return noticesList.map((item) => NoticeModel.fromJson(item as Map<String, dynamic>)).toList();
+    }
+  }
+
+  throw Exception("공지사항 데이터를 불러올 수 없습니다.");
+});

--- a/lib/features/notices/services/notice_service.g.dart
+++ b/lib/features/notices/services/notice_service.g.dart
@@ -9,7 +9,9 @@ part of 'notice_service.dart';
 // ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _NoticeService implements NoticeService {
-  _NoticeService(this._dio, {this.baseUrl, this.errorLogger});
+  _NoticeService(this._dio, {this.baseUrl, this.errorLogger}) {
+    baseUrl ??= 'http://aimory.ap-northeast-2.elasticbeanstalk.com';
+  }
 
   final Dio _dio;
 
@@ -60,26 +62,24 @@ class _NoticeService implements NoticeService {
   }
 
   @override
-  Future<List<NoticeModel>> getNotices(String token) async {
+  Future<dynamic> getNotices(String token) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{r'Authorization': token};
-    final _options = Options(
-      method: 'GET',
-      headers: _headers,
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<dynamic>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/notices',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
-
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-      _options.compose(_dio.options, '/notices'),
-    );
-
-    if (_result.data == null || !_result.data!.containsKey("notices")) {
-      throw Exception("잘못된 응답 형식: ${_result.data}");
-    }
-
-    // ✅ "notices" 키의 리스트를 직접 List<NoticeModel>로 변환
-    final List<NoticeModel> _value = (_result.data!["notices"] as List)
-        .map((e) => NoticeModel.fromJson(e as Map<String, dynamic>))
-        .toList();
-
+    final _result = await _dio.fetch(_options);
+    final _value = _result.data;
     return _value;
   }
 


### PR DESCRIPTION
 ## 💥 연관된 이슈
#99
#101

## 🔨 작업 내용
- createNoticeProvider 생성 및 noticeServiceProvider 수정
- 공지사항 등록 후 업데이트 기능 추가(NoticeInsertScreen)
- SwipeToDelete에 공지사항 삭제 API 연동(TeacherNoticeListScreen)
- Retrofit 응답 타입을 Future으로 변경하여 API 응답 처리 개선(NoticeService)
## 👀
![Screen_Recording_20250203_003253_1](https://github.com/user-attachments/assets/bf831e82-2eb0-43ec-a955-95a2299e2722)
![Screen_Recording_20250203_003350_1](https://github.com/user-attachments/assets/3329abb6-43c9-456a-8f21-06b54cf907b3)
작업 결과 이미지
