### PR TITLE
FEAT(#110): Rekognition 사진 업로드 API 연동

### DIFF
--- a/lib/features/home/screens/teacher_home_screen.dart
+++ b/lib/features/home/screens/teacher_home_screen.dart
@@ -221,7 +221,7 @@ class TeacherHomeScreen extends ConsumerWidget {
                                             builder: (context) => PhotoDetailScreen(
                                               photoId: photo.photoId, // ✅ 사진 ID
                                               imageUrl: photo.imageUrl, // ✅ 이미지 URL
-                                              title: photo.childName, // ✅ 아이 이름을 제목으로 설정
+                                              title: photo.childNames.isNotEmpty ? photo.childNames.first : "이름 없음", // ✅ 아이 이름을 제목으로 설정
                                               createdAt: formatDateTime(photo.createdAt), // ✅ 날짜 변환 후 전달
                                               role: 'teacher', // ✅ 교사용 역할 설정
                                             ),

--- a/lib/features/notices/screens/notice_insert_screen.dart
+++ b/lib/features/notices/screens/notice_insert_screen.dart
@@ -309,12 +309,21 @@ class _NoticeInsertScreenState extends ConsumerState<NoticeInsertScreen> {
                           ElevatedButton(
                             onPressed: pickImages,
                             style: ElevatedButton.styleFrom(
-                                elevation: 0,
-                                padding: const EdgeInsets.symmetric(
-                                    vertical: 12.0),
-                                backgroundColor: MAIN_YELLOW,
-                                foregroundColor: BLACK_COLOR),
-                            child: const Text("사진추가"),
+                              elevation: 0,
+                              backgroundColor: MAIN_YELLOW,
+                              foregroundColor: BLACK_COLOR,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10.0),
+                              ),
+                            ),
+                            child: const Text(
+                              "사진추가",
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w700,
+                                color: BLACK_COLOR,
+                              ),
+                            ),
                           ),
                     ),
                   ),

--- a/lib/features/photos/models/photo_model.dart
+++ b/lib/features/photos/models/photo_model.dart
@@ -1,15 +1,15 @@
 class PhotoModel {
   final int photoId;
   final String imageUrl;
-  final int childId;
-  final String childName; // ✅ 원아 이름 (Null 방지)
-  final String createdAt; // ✅ 업로드 날짜
+  final List<int> childIds; // ✅ 여러 childId 처리
+  final List<String> childNames; // ✅ 여러 childName 처리
+  final String createdAt;
 
   PhotoModel({
     required this.photoId,
     required this.imageUrl,
-    required this.childId,
-    required this.childName,
+    required this.childIds,
+    required this.childNames,
     required this.createdAt,
   });
 
@@ -18,9 +18,9 @@ class PhotoModel {
     return PhotoModel(
       photoId: json["photoId"] ?? 0,
       imageUrl: json["imageUrl"] ?? "",
-      childId: json["childId"] ?? 0,
-      childName: json["childName"] ?? "이름 없음", // ✅ null 방지
-      createdAt: json["createdAt"] ?? "날짜 없음", // ✅ null 방지
+      childIds: List<int>.from(json["childIds"] ?? []), // ✅ 여러 ID 처리
+      childNames: List<String>.from(json["childNames"] ?? []), // ✅ 여러 이름 처리
+      createdAt: json["createdAt"] ?? "날짜 없음",
     );
   }
 
@@ -29,8 +29,8 @@ class PhotoModel {
     return {
       "photoId": photoId,
       "imageUrl": imageUrl,
-      "childId": childId,
-      "childName": childName,
+      "childIds": childIds,
+      "childNames": childNames,
       "createdAt": createdAt,
     };
   }

--- a/lib/features/photos/provider/photo_provider.dart
+++ b/lib/features/photos/provider/photo_provider.dart
@@ -7,30 +7,111 @@ import '../models/photo_model.dart';
 import '../services/photo_service.dart';
 import '../../../core/util/secure_storage.dart';
 
+// final dioProvider = Provider<Dio>((ref) {
+//   final dio = Dio(BaseOptions(
+//     baseUrl: "http://aimory.ap-northeast-2.elasticbeanstalk.com",
+//   ));
+//   return dio;
+// });
+
+
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio(BaseOptions(
     baseUrl: "http://aimory.ap-northeast-2.elasticbeanstalk.com",
   ));
+
+  dio.interceptors.add(InterceptorsWrapper(
+    onRequest: (options, handler) async {
+      final token = await SecureStorage.readToken();
+      if (token == null) {
+        handler.reject(DioError(
+          requestOptions: options,
+          response: Response(
+            requestOptions: options,
+            statusCode: 401,
+            statusMessage: "Unauthorized: 토큰이 없습니다.",
+          ),
+        ));
+        return;
+      }
+
+      options.headers["Authorization"] = "Bearer $token";
+      handler.next(options);
+    },
+    onError: (DioError e, handler) async {
+      if (e.response?.statusCode == 401) {
+        print("❌ 401 오류 발생: 토큰 재발급 시도");
+        await SecureStorage.deleteAuthData(); // 기존 토큰 삭제
+        handler.reject(e);
+      } else {
+        handler.next(e);
+      }
+    },
+  ));
+
   return dio;
 });
 
 
-final photoUploadProvider = FutureProvider.family<bool, File>((ref, file) async {
+// final photoUploadProvider = FutureProvider.family<bool, File>((ref, file) async {
+//   final token = await SecureStorage.readToken();
+//   if (token == null) {
+//     throw Exception("❌ 토큰이 없습니다.");
+//   }
+//
+//   try {
+//     final fileData = await MultipartFile.fromFile(file.path, filename: file.path.split('/').last);
+//
+//     // 🔥 Authorization 헤더 직접 추가
+//     final response = await dio.post(
+//       "/photos",
+//       data: FormData.fromMap({
+//         "files": [fileData],  // 🔹 key를 서버 스펙에 맞춰야 함
+//       }),
+//       options: Options(
+//         headers: {
+//           "Authorization": "Bearer $token",
+//           "Content-Type": "multipart/form-data",
+//         },
+//       ),
+//     );
+//
+//     debugPrint("✅ 사진 업로드 성공: ${response.data}");
+//     ref.invalidate(photoListProvider); // ✅ 업로드 후 새로고침
+//     return true;
+//   } catch (e) {
+//     debugPrint("❌ 사진 업로드 실패: $e");
+//     return false;
+//   }
+// });
+
+
+final photoUploadProvider = FutureProvider.family<bool, List<File>>((ref, files) async {
   final service = ref.read(photoServiceProvider);
   final token = await SecureStorage.readToken();
+
   if (token == null) {
-    throw Exception("❌ 토큰이 없습니다.");
+    print("❌ 토큰이 없습니다. 다시 로그인 필요.");
+    throw Exception("❌ 인증 토큰이 없습니다. 다시 로그인해주세요.");
   }
 
   try {
-    final fileData = await MultipartFile.fromFile(file.path, filename: file.path.split('/').last);
-    final response = await service.uploadPhotos("Bearer $token", [fileData]); // ✅ childId 제거
+    final List<MultipartFile> multipartImages = await Future.wait(
+        files.map((file) async => MultipartFile.fromFile(file.path, filename: file.path.split('/').last))
+    );
 
-    debugPrint("✅ 사진 업로드 성공");
-    ref.invalidate(photoListProvider); // ✅ 업로드 후 새로고침
+    print("🟡 업로드 요청 - 파일 개수: ${multipartImages.length}");
+
+    final response = await service.uploadPhotos("Bearer $token", multipartImages);
+
+    print("✅ 사진 업로드 성공: ${response}");
     return true;
   } catch (e) {
-    debugPrint("❌ 사진 업로드 실패: $e");
+    print("❌ 사진 업로드 실패: $e");
+    if (e is DioError && e.response?.statusCode == 401) {
+      await SecureStorage.deleteAuthData();
+      print("🔄 토큰 만료: 로그아웃 처리");
+    }
     return false;
   }
 });
@@ -60,20 +141,24 @@ final photoServiceProvider = Provider<PhotoService>((ref) {
 final photoListProvider = FutureProvider<List<PhotoModel>>((ref) async {
   final service = ref.read(photoServiceProvider);
   final token = await SecureStorage.readToken();
+
+  debugPrint("🟡 저장된 토큰: $token");
+
   if (token == null) {
-    throw Exception("토큰이 존재하지 않습니다.");
+    throw Exception("❌ 토큰이 없습니다.");
   }
 
   final rawResponse = await service.getPhotos("Bearer $token");
   debugPrint("📸 사진첩 API 원본 응답: $rawResponse");
 
-  // 🔹 응답이 `Map<String, dynamic>`이면 `{ "photos": [...] }` 형태일 가능성 높음
   if (rawResponse is Map<String, dynamic> && rawResponse.containsKey("photos")) {
     final photosList = rawResponse["photos"];
+    debugPrint("📸 응답에서 추출한 photos 데이터: $photosList");
+
     if (photosList is List) {
       return photosList.map((item) => PhotoModel.fromJson(item as Map<String, dynamic>)).toList();
     }
   }
 
-  throw Exception("사진 데이터를 불러올 수 없습니다.");
+  throw Exception("❌ 사진 데이터를 불러올 수 없습니다. 응답 확인 필요");
 });

--- a/lib/features/photos/screens/photo_insert_screen.dart
+++ b/lib/features/photos/screens/photo_insert_screen.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import '../../../core/const/colors.dart';
+import '../../../core/widgets/custom_button.dart';
+import '../../../core/widgets/multi_image_picker.dart';
+import '../../../core/util/secure_storage.dart';
+import '../provider/photo_provider.dart';
+import '../services/photo_service.dart';
+
+class PhotoInsertScreen extends ConsumerStatefulWidget {
+  const PhotoInsertScreen({Key? key}) : super(key: key);
+
+  @override
+  ConsumerState<PhotoInsertScreen> createState() => _PhotoInsertScreenState();
+}
+
+class _PhotoInsertScreenState extends ConsumerState<PhotoInsertScreen> {
+  List<File> _selectedImages = [];
+
+  void _removeImage(int index) {
+    setState(() {
+      _selectedImages.removeAt(index);
+    });
+  }
+
+  Future<void> _uploadPhotos() async {
+    if (_selectedImages.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("사진을 선택해주세요.")));
+      return;
+    }
+
+    bool? isConfirmed = await _showConfirmDialog();
+    if (isConfirmed != true) return;
+
+    final result = await ref.read(photoUploadProvider(_selectedImages).future);
+
+    if (result) {
+      ref.invalidate(photoListProvider); // ✅ 업로드 성공 후 최신화
+      await _showSuccessDialog();
+      Navigator.pop(context, true); // ✅ true 반환하여 새로고침 트리거
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("사진 등록 실패. 다시 시도해주세요.")));
+    }
+  }
+
+  Future<bool?> _showConfirmDialog() async {
+    return await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          backgroundColor: Colors.white,
+          title: const Text("사진 등록", style: TextStyle(color: DARK_GREY_COLOR)),
+          content: const Text("사진을 등록하시겠습니까?", style: TextStyle(color: DARK_GREY_COLOR)),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text("취소", style: TextStyle(color: Colors.black)),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              style: ElevatedButton.styleFrom(backgroundColor: DARK_GREY_COLOR),
+              child: const Text("확인", style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _showSuccessDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          backgroundColor: Colors.white,
+          title: const Text("사진 등록 완료", style: TextStyle(color: DARK_GREY_COLOR)),
+          content: const Text("사진이 성공적으로 등록되었습니다.", style: TextStyle(color: DARK_GREY_COLOR)),
+          actions: [
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              style: ElevatedButton.styleFrom(backgroundColor: DARK_GREY_COLOR),
+              child: const Text("확인", style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: MAIN_YELLOW,
+        centerTitle: true,
+        title: const Text("사진 추가", style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w600)),
+        leading: IconButton(icon: const Icon(Icons.keyboard_backspace),
+            onPressed: () => Navigator.pop(context)),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: MultiImagePicker(
+                    onImagesPicked: (pickedFiles) {
+                      setState(() {
+                        _selectedImages.addAll(pickedFiles.map((file) => File(file.path)));
+                      });
+                    },
+                    builder: (context, pickImages) => ElevatedButton(
+                      onPressed: pickImages,
+                      style: ElevatedButton.styleFrom(
+                        elevation: 0,
+                        backgroundColor: MAIN_YELLOW,
+                        foregroundColor: BLACK_COLOR,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10.0),
+                        ),
+                      ),
+                      child: const Text(
+                        "사진추가",
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: BLACK_COLOR,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (_selectedImages.isNotEmpty)
+              Wrap(
+                spacing: 8.0,
+                runSpacing: 8.0,
+                children: _selectedImages.asMap().entries.map((entry) {
+                  int index = entry.key;
+                  File image = entry.value;
+                  return Stack(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8.0),
+                        child: Image.file(image, width: 100, height: 100, fit: BoxFit.cover),
+                      ),
+                      Positioned(
+                        top: 0,
+                        right: 0,
+                        child: GestureDetector(
+                          onTap: () => _removeImage(index),
+                          child: const CircleAvatar(
+                            radius: 10,
+                            backgroundColor: MAIN_YELLOW,
+                            child: Icon(Icons.close, color: MAIN_DARK_GREY, size: 14),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                }).toList(),
+              ),
+            const SizedBox(height: 16),
+
+            CustomButton(
+              text: "등록하기",
+              onPressed: _uploadPhotos,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/photos/screens/teacher_photo_list_screen.dart
+++ b/lib/features/photos/screens/teacher_photo_list_screen.dart
@@ -7,15 +7,15 @@ import '../provider/photo_provider.dart';
 
 class TeacherPhotoListScreen extends ConsumerStatefulWidget {
   final String childName;
-  final int childId;
-  final int photoCount; // ✅ 추가해야 함!
+  final int? childId;
+  final int photoCount;
   final List<Map<String, dynamic>> allPhotos;
 
   const TeacherPhotoListScreen({
     Key? key,
     required this.childName,
-    required this.childId,
-    required this.photoCount, // ✅ 추가!
+    this.childId,
+    required this.photoCount,
     required this.allPhotos,
   }) : super(key: key);
 
@@ -38,9 +38,11 @@ class _TeacherPhotoListScreenState extends ConsumerState<TeacherPhotoListScreen>
       if (widget.childId == -1) {
         filteredPhotos = widget.allPhotos; // ✅ 전체 앨범
       } else {
-        filteredPhotos = widget.allPhotos
-            .where((photo) => photo['childId'] == widget.childId)
-            .toList();
+        filteredPhotos = widget.allPhotos.where((photo) {
+          final List<dynamic>? childIds = photo['childIds'];
+          if (childIds == null || childIds.isEmpty) return false;
+          return childIds.contains(widget.childId); // ✅ childIds 리스트 내 포함 여부 확인
+        }).toList();
       }
     });
 

--- a/lib/features/photos/services/photo_service.dart
+++ b/lib/features/photos/services/photo_service.dart
@@ -15,7 +15,7 @@ abstract class PhotoService {
   @POST("/photos")
   @MultiPart()
   Future<dynamic> uploadPhotos(
-      @Header("apiToken") String token,
+      @Header("Authorization") String token,
       @Part() List<MultipartFile> files,
       );
 
@@ -32,12 +32,13 @@ abstract class PhotoService {
       );
 }
 
-// ✅ Dio 인스턴스에서 요청/응답 로그 출력
+// ✅ Dio 인스턴스에서 요청/응답 로그 출력 (토큰 포함 여부 확인)
 final dio = Dio(BaseOptions(baseUrl: "http://aimory.ap-northeast-2.elasticbeanstalk.com"))
   ..interceptors.add(InterceptorsWrapper(
     onRequest: (options, handler) {
       debugPrint("📤 요청 URL: ${options.uri}");
       debugPrint("📤 요청 헤더: ${options.headers}");
+      debugPrint("📤 요청 데이터: ${options.data}");
       return handler.next(options);
     },
     onResponse: (response, handler) {

--- a/lib/features/photos/services/photo_service.g.dart
+++ b/lib/features/photos/services/photo_service.g.dart
@@ -42,6 +42,34 @@ class _PhotoService implements PhotoService {
   }
 
   @override
+  Future<dynamic> uploadPhotos(String token, List<MultipartFile> files) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'apiToken': token};
+    _headers.removeWhere((k, v) => v == null);
+    final _data = FormData();
+    _data.files.addAll(files.map((i) => MapEntry('files', i)));
+    final _options = _setStreamType<dynamic>(
+      Options(
+        method: 'POST',
+        headers: _headers,
+        extra: _extra,
+        contentType: 'multipart/form-data',
+      )
+          .compose(
+            _dio.options,
+            '/photos',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch(_options);
+    final _value = _result.data;
+    return _value;
+  }
+
+  @override
   Future<dynamic> getPhotosByChild(String token, int childId) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{r'childId': childId};


### PR DESCRIPTION
 ## 💥 연관된 이슈
#110

## 🔨 작업 내용
- 토큰 만료 시 자동 로그아웃 추가
- 사진추가 버튼 디자인 변경
- Photo Model childId, childName 리스트화
- 토큰 만료시 재로그인 기능 추가
- 헤더 apiToken에서 Authorization으로 변경
- childId 그룹화, 사진 추가하기 버튼 PhotoInsertScreen으로 이동
- 아이이름 title 수정
- 아이 이름(title) 표시 수정 및 photoCount 추가
- PhotoInsertScreen 생성하여 이미지업로드 API 연동

## 👀작업 결과 이미지
![dsdd](https://github.com/user-attachments/assets/01f385ab-596a-4612-84cb-df1ca979779a)
