### PR TITLE
FEAT(#118): 알림장 삭제 API 연동

### DIFF
--- a/lib/features/notes/provider/note_provider.dart
+++ b/lib/features/notes/provider/note_provider.dart
@@ -59,3 +59,18 @@ final noteDetailProvider = FutureProvider.autoDispose.family<NoteModel, int>((re
   return service.fetchNoteDetail("Bearer $token", noteId);
 });
 
+// ✅ 알림장 삭제 Provider
+final noteDeleteProvider = FutureProvider.family<void, int>((ref, noteId) async {
+  final service = ref.read(noteServiceProvider);
+  final token = await SecureStorage.readToken();
+  if (token == null) {
+    throw Exception("토큰이 존재하지 않습니다.");
+  }
+
+  await service.deleteNotes("Bearer $token", {"data": [noteId]});
+
+  // ✅ 삭제 후 목록 갱신
+  ref.invalidate(noteListProvider);
+});
+
+

--- a/lib/features/notes/screens/note_insert_screen.dart
+++ b/lib/features/notes/screens/note_insert_screen.dart
@@ -54,6 +54,62 @@ class _NoteInsertScreenState extends ConsumerState<NoteInsertScreen> {
     });
   }
 
+  /// ✅ 알림장 등록 확인 다이얼로그
+  Future<bool?> _showRegisterConfirmDialog() async {
+    return await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          backgroundColor: Colors.white,
+          title: const Text("알림장 등록", style: TextStyle(color: DARK_GREY_COLOR)),
+          content: const Text("알림장을 등록하시겠습니까?", style: TextStyle(color: DARK_GREY_COLOR)),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text("취소", style: TextStyle(color: Colors.black)),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: DARK_GREY_COLOR,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              ),
+              child: const Text("확인", style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// ✅ 알림장 등록 성공 다이얼로그
+  Future<void> _showRegisterSuccessDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          backgroundColor: Colors.white,
+          title: const Text("알림장 등록 완료", style: TextStyle(color: DARK_GREY_COLOR)),
+          content: const Text("알림장이 성공적으로 등록되었습니다.", style: TextStyle(color: DARK_GREY_COLOR)),
+          actions: [
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context, true);
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: DARK_GREY_COLOR,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              ),
+              child: const Text("확인", style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   void _openCustomDatePicker(BuildContext context) {
     showModalBottomSheet(
       backgroundColor: Colors.white,
@@ -156,8 +212,13 @@ class _NoteInsertScreenState extends ConsumerState<NoteInsertScreen> {
       "image": _previewImageUrl!,
     };
 
+
+    final confirm = await _showRegisterConfirmDialog();
+
     try {
       await ref.read(noteCreateProvider(requestData).future);
+
+      await _showRegisterSuccessDialog();
 
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text("알림장이 성공적으로 등록되었습니다.")),

--- a/lib/features/notes/screens/teacher_note_list_screen.dart
+++ b/lib/features/notes/screens/teacher_note_list_screen.dart
@@ -8,6 +8,36 @@ import '../models/note_model.dart';
 import '../provider/note_provider.dart';
 
 class TeacherNoteListScreen extends ConsumerWidget {
+
+  /// ✅ 알림장 삭제 확인 다이얼로그
+  Future<bool?> _showDeleteConfirmDialog(BuildContext context) async {
+    return await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          backgroundColor: Colors.white,
+          title: const Text("알림장 삭제", style: TextStyle(color: DARK_GREY_COLOR)),
+          content: const Text("해당 알림장을 삭제하시겠습니까?", style: TextStyle(color: DARK_GREY_COLOR)),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text("취소", style: TextStyle(color: Colors.black)),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: DARK_GREY_COLOR,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              ),
+              child: const Text("삭제", style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final noteListAsync = ref.watch(noteListProvider); // ✅ 알림장 전체 조회 API 호출
@@ -77,9 +107,20 @@ class TeacherNoteListScreen extends ConsumerWidget {
                 itemBuilder: (context, index) {
                   NoteModel note = notes[index];
                   return SwipeToDelete(
-                    onDelete: () {
-                      // ✅ 삭제 기능 추가 가능 (현재는 UI에서만 제거)
-                      // ref.read(noteListProvider.notifier).fetchNotes();
+                    onDelete: () async {
+                      final confirm = await _showDeleteConfirmDialog(context);
+                      if (confirm != true) return;
+
+                      try {
+                        await ref.read(noteDeleteProvider(note.id!).future);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text("알림장이 삭제되었습니다.")),
+                        );
+                      } catch (e) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text("삭제 실패: $e")),
+                        );
+                      }
                     },
                     child: GestureDetector(
                       onTap: () async {

--- a/lib/features/notes/services/note_service.dart
+++ b/lib/features/notes/services/note_service.dart
@@ -27,4 +27,11 @@ abstract class NoteService {
       @Header("Authorization") String token,
       @Path("note_id") int noteId,
       );
+
+  // 알림장 삭제 API
+  @DELETE("/notes")
+  Future<void> deleteNotes(
+      @Header("Authorization") String token,
+      @Body() Map<String, dynamic> noteIds, // { "data": [noteId] } 형태로 전송
+      );
 }

--- a/lib/features/notes/services/note_service.g.dart
+++ b/lib/features/notes/services/note_service.g.dart
@@ -90,6 +90,27 @@ class _NoteService implements NoteService {
     return _value;
   }
 
+  @override
+  Future<void> deleteNotes(String token, Map<String, dynamic> noteIds) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'Authorization': token};
+    _headers.removeWhere((k, v) => v == null);
+    final _data = <String, dynamic>{};
+    _data.addAll(noteIds);
+    final _options = _setStreamType<void>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/notes',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/features/notices/screens/notice_insert_screen.dart
+++ b/lib/features/notices/screens/notice_insert_screen.dart
@@ -170,7 +170,10 @@ class _NoticeInsertScreenState extends ConsumerState<NoticeInsertScreen> {
             ),
             ElevatedButton(
               onPressed: () => Navigator.pop(context, true),
-              style: ElevatedButton.styleFrom(backgroundColor: DARK_GREY_COLOR),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: DARK_GREY_COLOR,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              ),
               child: const Text("확인", style: TextStyle(color: Colors.white)),
             ),
           ],


### PR DESCRIPTION
 ## 💥 연관된 이슈
#118

## 🔨 작업 내용
- 다이얼로그 버튼 디자인 변경
- 삭제 다이얼로그 추가
- UI 알림장 삭제 API 연동
- 알림장 삭제 기능

## 👀 작업 결과 이미지
![Screen_Recording_20250205_005231_1](https://github.com/user-attachments/assets/1ac123ef-64e3-41f3-be2c-9b8c081bf424)
