### PR TITLE
FEAT(#128): 로그아웃 기능 구현

### DIFF
--- a/lib/features/auth/screens/parent_info_screen.dart
+++ b/lib/features/auth/screens/parent_info_screen.dart
@@ -125,12 +125,12 @@ class ParentInfoScreen extends StatelessWidget {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         mainAxisSize: MainAxisSize.max,
                         children: [
-                          Icon(Icons.call_sharp, size: 25.0,),
+                          Icon(Icons.logout_sharp, size: 25.0,),
                           SizedBox(height: 10.0,),
                           SizedBox(
                             width: 80.0, // 버튼의 고정 너비 설정
                             child: Text(
-                              '고객센터', // 예시 텍스트
+                              '로그아웃', // 예시 텍스트
                               textAlign: TextAlign.center, // 텍스트 가운데 정렬
                               style: TextStyle(fontSize: 12, color: BLACK_COLOR,),
                               maxLines: 2, // 최대 줄 수 설정

--- a/lib/features/auth/screens/teacher_info_screen.dart
+++ b/lib/features/auth/screens/teacher_info_screen.dart
@@ -1,8 +1,10 @@
 import 'package:aimory_app/core/const/colors.dart';
 import 'package:aimory_app/features/auth/providers/teacher_provider.dart';
+import 'package:aimory_app/features/auth/screens/signin_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/util/secure_storage.dart';
 import 'center_info_insert_screen.dart';
 import 'info_insert_screen.dart';
 
@@ -129,7 +131,14 @@ class TeacherInfoScreen extends ConsumerWidget {
                       color: MID_GREY_COLOR,
                     ),
                     GestureDetector(
-                      onTap: () {},
+                      onTap: () async {
+                        await SecureStorage.deleteAuthData(); // 인증 정보 삭제
+                        Navigator.pushAndRemoveUntil(
+                          context,
+                          MaterialPageRoute(builder: (context) => const SignInScreen()), // 로그인 화면으로 이동
+                              (route) => false, // 이전 화면 스택 제거
+                        );
+                      },
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.center,
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/features/auth/screens/teacher_info_screen.dart
+++ b/lib/features/auth/screens/teacher_info_screen.dart
@@ -135,12 +135,12 @@ class TeacherInfoScreen extends ConsumerWidget {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         mainAxisSize: MainAxisSize.max,
                         children: [
-                          Icon(Icons.call_sharp, size: 25.0,),
+                          Icon(Icons.logout_sharp, size: 25.0,),
                           SizedBox(height: 10.0,),
                           SizedBox(
                             width: 80.0, // 버튼의 고정 너비 설정
                             child: Text(
-                              '고객센터', // 예시 텍스트
+                              '로그아웃', // 예시 텍스트
                               textAlign: TextAlign.center, // 텍스트 가운데 정렬
                               style: TextStyle(fontSize: 12, color: BLACK_COLOR,),
                               maxLines: 2, // 최대 줄 수 설정


### PR DESCRIPTION
 ## 💥 연관된 이슈
#128

## 🔨 작업 내용
- 로그아웃 버튼 내정보 스크린에 추가(기존 고객센터 버튼 삭제)
- Secure Storage에서 토큰 정보 삭제하여 스크린에 연동
- Navigator.pushAndRemoveUntil()을 통해 로그인 화면으로 강제 이동하며, 기존 화면 스택을 모두 제거하여 사용자가 뒤로 가기를 눌러도 다시 돌아오지 못하도록 처리함.
