### PR TITLE
FEAT(#138): 아이등록/교사등록 스크린 생성 및 UI 구현

### DIFF
--- a/lib/features/director_settings/screens/children_insert_screen.dart
+++ b/lib/features/director_settings/screens/children_insert_screen.dart
@@ -1,0 +1,103 @@
+import 'package:aimory_app/core/const/colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/widgets/custom_button.dart';
+import '../../../core/widgets/custom_input_decoration.dart';
+
+class ChildrenInsertScreen extends ConsumerStatefulWidget {
+  const ChildrenInsertScreen({super.key});
+
+  @override
+  _ChildrenInsertScreenState createState() => _ChildrenInsertScreenState();
+}
+
+class _ChildrenInsertScreenState extends ConsumerState<ChildrenInsertScreen> {
+  List<String> childrenList = ["박채은", "김민수", "이서연", "정하늘", "한지민","박채은", "김민수", "이서연", "정하늘", "한지민","박채은", "김민수", "이서연", "정하늘", "한지민"]; // 예제 데이터
+
+  // 아이템 삭제 함수
+  void _deleteItem(int index) {
+    setState(() {
+      childrenList.removeAt(index);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: MAIN_YELLOW,
+        centerTitle: true,
+        title: const Text("원아 등록", style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w600)),
+        leading: IconButton(
+            icon: const Icon(Icons.keyboard_backspace),
+            onPressed: () => Navigator.pop(context)),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(30.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 16),
+              const Text('원아 이름'),
+              const SizedBox(height: 8),
+              TextFormField(
+                decoration: CustomInputDecoration.basic(
+                  hintText: '원아 이름을 입력하세요.',
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // 리스트 아이템 생성 (스크롤 가능)
+              Expanded(
+                child: ListView.builder(
+                  itemCount: childrenList.length,
+                  itemBuilder: (context, index) {
+                    return GestureDetector(
+                      onTap: () {
+                        debugPrint("아이템 클릭: ${childrenList[index]}");
+                      },
+                      child: Container(
+                        margin: const EdgeInsets.symmetric(vertical: 5.0), // 아이템 간 간격 추가
+                        padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(12), // 둥근 테두리
+                          border: Border.all(color: BORDER_GREY_COLOR, width: 1), // 개별 테두리
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            // 아이 이름
+                            Text(
+                              childrenList[index],
+                              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                            ),
+                            // X 삭제 버튼
+                            IconButton(
+                              icon: Icon(Icons.close, color: MAIN_DARK_GREY),
+                              onPressed: () => _deleteItem(index),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+
+              const SizedBox(height: 24),
+              CustomButton(
+                text: '등록하기',
+                onPressed: () {
+                  //TODO: 등록하기 이벤트 리스너
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/director_settings/screens/class_setting_screen.dart
+++ b/lib/features/director_settings/screens/class_setting_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:aimory_app/core/const/colors.dart';
+import 'package:aimory_app/features/director_settings/screens/teacher_insert_screen.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/widgets/custom_button.dart';
 import '../../../core/widgets/custom_input_decoration.dart';
 import 'center_insert_screen.dart';
+import 'children_insert_screen.dart';
 import 'class_insert_screen.dart';
 
 class ClassSettingScreen extends ConsumerWidget {
@@ -175,7 +177,7 @@ class ClassSettingScreen extends ConsumerWidget {
                                 onPressed: () async {
                                   final result = await Navigator.push(
                                     context,
-                                    MaterialPageRoute(builder: (context) => const CenterInsertScreen()),
+                                    MaterialPageRoute(builder: (context) => const ChildrenInsertScreen()),
                                   );
                                 },
                                 label: const Text(
@@ -198,7 +200,7 @@ class ClassSettingScreen extends ConsumerWidget {
                                 onPressed: () async {
                                   final result = await Navigator.push(
                                     context,
-                                    MaterialPageRoute(builder: (context) => const CenterInsertScreen()),
+                                    MaterialPageRoute(builder: (context) => const TeacherInsertScreen()),
                                   );
                                 },
                                 label: const Text(

--- a/lib/features/director_settings/screens/teacher_insert_screen.dart
+++ b/lib/features/director_settings/screens/teacher_insert_screen.dart
@@ -1,0 +1,84 @@
+import 'dart:developer';
+
+import 'package:aimory_app/core/const/colors.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/widgets/custom_button.dart';
+import '../../../core/widgets/custom_input_decoration.dart';
+
+class TeacherInsertScreen extends ConsumerWidget {
+  const TeacherInsertScreen({super.key});
+
+
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: MAIN_YELLOW,
+        centerTitle: true,
+        title: const Text("담임교사 등록", style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w600)),
+        leading: IconButton(icon: const Icon(Icons.keyboard_backspace), onPressed: () => Navigator.pop(context)),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(30.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 16),
+                const Text('교사 이름'),
+                const SizedBox(height: 8),
+                TextFormField(
+                  // controller: emailController,
+                  decoration: CustomInputDecoration.basic(
+                    hintText: '교사 이름을 입력하세요.',
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Container(
+                  margin: const EdgeInsets.symmetric(vertical: 5.0), // 아이템 간 간격 추가
+                  padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(12), // 둥근 테두리
+                    border: Border.all(color: BORDER_GREY_COLOR, width: 1), // 개별 테두리
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      // 아이 이름
+                      Text(
+                        "김지은",
+                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                      ),
+                      // X 삭제 버튼
+                      IconButton(
+                        icon: Icon(Icons.close, color: MAIN_DARK_GREY),
+                        onPressed: () {
+                          // TODO: 삭제 리스너 달기
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+
+                const SizedBox(height: 24),
+                CustomButton(
+                  text: '등록하기',
+                  onPressed: () {
+                    //TODO: 등록하기 이벤트 리스너
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 💥 연관된 이슈
#138

## 🔨 작업 내용
- 아이 등록하기 스크린 생성
- 교사 등록하기 스크린 생성
- 아이/교사 구현 UI 구현
- 반 설정 스크린(ClassSettingScreen) [아이등록], [교사등록] 버튼과 연동

## 👀 작업 결과 이미지
<img width="371" alt="스크린샷 2025-03-03 오후 5 21 53" src="https://github.com/user-attachments/assets/e0cbe7e1-8146-4e48-a7e1-66fd69b47690" />
<img width="371" alt="스크린샷 2025-03-03 오후 5 22 01" src="https://github.com/user-attachments/assets/b5998f59-3fae-4de5-944d-18a3b2a860e8" />
