### PR TITLE
FEAT(#144): 부모 메인 홈 공지사항 리스트 3개까지만 노출되도록 수정

### DIFF
--- a/lib/features/auth/screens/parent_info_screen.dart
+++ b/lib/features/auth/screens/parent_info_screen.dart
@@ -103,7 +103,7 @@ class ParentInfoScreen extends StatelessWidget {
                           SizedBox(
                             width: 80.0, // 버튼의 고정 너비 설정
                             child: Text(
-                              '아이 정보 등', // 예시 텍스트
+                              '아이 정보 등록', // 예시 텍스트
                               textAlign: TextAlign.center, // 텍스트 가운데 정렬
                               style: TextStyle(fontSize: 12, color: BLACK_COLOR,),
                               maxLines: 2, // 최대 줄 수 설정

--- a/lib/features/home/screens/parent_home_screen.dart
+++ b/lib/features/home/screens/parent_home_screen.dart
@@ -62,53 +62,60 @@ class ParentHomeScreen extends ConsumerWidget {
 
                         // ✅ 공지사항 API 연동
                         noticeListAsync.when(
-                          data: (notices) => Container(
-                            margin: EdgeInsets.zero,
-                            padding: EdgeInsets.zero,
-                            decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(color: BORDER_GREY_COLOR, width: 1),
-                            ),
-                            child: ListView.builder(
+                          data: (notices) {
+                            // ✅ 최신 3개만 가져오도록 리스트 제한
+                            final latestNotices = notices.length > 3 ? notices.take(3).toList() : notices;
+
+                            return Container(
+
+                              margin: EdgeInsets.zero,
                               padding: EdgeInsets.zero,
-                              shrinkWrap: true,
-                              physics: const NeverScrollableScrollPhysics(),
-                              itemCount: notices.length,
-                              itemBuilder: (context, index) {
-                                final notice = notices[index];
-                                return GestureDetector(
-                                  onTap: () {
-                                    Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) => ParentNoticeDetailScreen(noticeId: notice.id ?? 0),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(color: BORDER_GREY_COLOR, width: 1),
+                              ),
+                              child: ListView.builder(
+                                padding: EdgeInsets.zero,
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: latestNotices.length, // ✅ API에서 가져온 데이터 개수
+                                itemBuilder: (context, index) {
+                                  final notice = latestNotices[index];
+                                  return GestureDetector(
+                                    onTap: () {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) =>
+                                              ParentNoticeDetailScreen(noticeId: notice.id ?? 0),
+                                        ),
+                                      );
+                                    },
+                                    child: Container(
+                                      margin: const EdgeInsets.all(0),
+                                      decoration: BoxDecoration(
+                                        borderRadius: BorderRadius.circular(12),
+                                        color: Colors.white, // 배경색
                                       ),
-                                    );
-                                  },
-                                  child: Container(
-                                    margin: const EdgeInsets.all(0),
-                                    decoration: BoxDecoration(
-                                      borderRadius: BorderRadius.circular(12),
-                                      color: Colors.white,
+                                      child: Column(
+                                        children: [
+                                          ListTile(
+                                            title: Text(notice.title),
+                                            subtitle: Text(notice.title),
+                                          ),
+                                          Container(
+                                            margin: EdgeInsets.symmetric(horizontal: 10.0),
+                                            height: 1,
+                                            color: BORDER_GREY_COLOR,
+                                          ),
+                                        ],
+                                      ),
                                     ),
-                                    child: Column(
-                                      children: [
-                                        ListTile(
-                                          title: Text(notice.title),
-                                          subtitle: Text(notice.title),
-                                        ),
-                                        Container(
-                                          margin: EdgeInsets.symmetric(horizontal: 10.0),
-                                          height: 1,
-                                          color: BORDER_GREY_COLOR,
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
-                          ),
+                                  );
+                                },
+                              ),
+                            );
+                          },
                           loading: () => Center(child: CircularProgressIndicator()),
                           error: (err, stack) => Center(child: Text("공지사항을 불러올 수 없습니다. 🚨")),
                         ),


### PR DESCRIPTION
## 💥 연관된 이슈
#144

## 🔨 작업 내용
- 공지사항 리스트 부분 리스트 3개로 제한

## 👀 작업 결과 이미지
<img width="371" alt="스크린샷 2025-03-06 오후 3 25 34" src="https://github.com/user-attachments/assets/dc298265-d25c-43db-a412-7538696deb9f" />
